### PR TITLE
bugfix for hook and writeback

### DIFF
--- a/cache/cache.hpp
+++ b/cache/cache.hpp
@@ -240,13 +240,13 @@ public:
   }
 
   virtual void hook_read(uint64_t addr, uint32_t ai, uint32_t s, uint32_t w, bool hit, uint64_t *delay) {
-    if(hit) replacer[ai].access(s, w);
+    replacer[ai].access(s, w);
     if constexpr (EnMon) for(auto m:this->monitors) m->read(addr, ai, s, w, hit);
     if constexpr (!std::is_void<DLY>::value) timer->read(addr, ai, s, w, hit, delay);
   }
 
   virtual void hook_write(uint64_t addr, uint32_t ai, uint32_t s, uint32_t w, bool hit, uint64_t *delay) {
-    if(hit) replacer[ai].access(s, w);
+    replacer[ai].access(s, w);
     if constexpr (EnMon) for(auto m:this->monitors) m->write(addr, ai, s, w, hit);
     if constexpr (!std::is_void<DLY>::value) timer->write(addr, ai, s, w, hit, delay);
   }

--- a/cache/msi.hpp
+++ b/cache/msi.hpp
@@ -283,10 +283,10 @@ public:
   virtual void writeback_resp(uint64_t addr, CMDataBase *data_inner, uint32_t cmd, uint64_t *delay) {
     if (isLLC || Policy::is_release(cmd)) {
       uint32_t ai, s, w;
-      bool writeback, hit = this->cache->hit(addr, &ai, &s, &w); // must hit
+      bool writeback, hit = this->cache->hit(addr, &ai, &s, &w); 
       CMMetadataBase *meta = nullptr;
       if(Policy::is_release(cmd)) {
-        assert(hit);
+        assert(hit); // must hit
         meta = this->cache->access(ai, s ,w);
         if constexpr (!std::is_void<DT>::value) this->cache->get_data(ai, s, w)->copy(data_inner);
         Policy::meta_after_release(cmd, meta);


### PR DESCRIPTION
- regardless of whether it is hit or not, the replacer should access;
- When the command used for writeback is flush, cache may not necessarily hit;