### PR TITLE
clean up the pollution to CacheBase form Mirage [step 2, replace]

### DIFF
--- a/cache/cache.hpp
+++ b/cache/cache.hpp
@@ -170,8 +170,6 @@ public:
   virtual bool hit(uint64_t addr) = 0;
 
   virtual void replace(uint64_t addr, uint32_t *ai, uint32_t *s, uint32_t *w) = 0;
-  virtual void replace(uint64_t addr, uint32_t ai, uint32_t *s, uint32_t *w) {} // only useful for mirage
-  //virtual void replace(uint64_t addr, std::vector<std::pair<std::pair<uint32_t, uint32_t>, uint32_t> > &location) {} // only useful for mirage, obtain free locations in each skew
 
   // hook interface for replacer state update, Monitor and delay estimation
   virtual void hook_read(uint64_t addr, uint32_t ai, uint32_t s, uint32_t w, bool hit, uint64_t *delay) = 0;
@@ -180,12 +178,7 @@ public:
   virtual void hook_manage(uint64_t addr, uint32_t ai, uint32_t s, uint32_t w, bool hit, bool evict, bool writeback, uint64_t *delay) = 0;
 
   virtual CMMetadataBase *access(uint32_t ai, uint32_t s, uint32_t w) = 0;
-  virtual CMDataBase *get_data(uint32_t ai, uint32_t s, uint32_t w) { return nullptr;} // not implement in mirage
-
-  virtual CMMetadataBase *access(uint32_t d_s, uint32_t d_w) { return nullptr; } // only useful for mirage, obtain data meta
-  virtual CMDataBase *get_data(uint32_t d_s, uint32_t d_w) { return nullptr; }  // only useful for mirage
-
-  virtual void replace_data(uint64_t addr, uint32_t *ds, uint32_t *dw) {} // only useful for mirage, obtain replace's data
+  virtual CMDataBase *get_data(uint32_t ai, uint32_t s, uint32_t w) = 0;
 
   virtual bool query_coloc(uint64_t addrA, uint64_t addrB) = 0;
 

--- a/cache/cache.hpp
+++ b/cache/cache.hpp
@@ -171,7 +171,7 @@ public:
 
   virtual void replace(uint64_t addr, uint32_t *ai, uint32_t *s, uint32_t *w) = 0;
   virtual void replace(uint64_t addr, uint32_t ai, uint32_t *s, uint32_t *w) {} // only useful for mirage
-  virtual void replace(uint64_t addr, std::vector<std::pair<std::pair<uint32_t, uint32_t>, uint32_t> > &location) {} // only useful for mirage, obtain free locations in each skew
+  //virtual void replace(uint64_t addr, std::vector<std::pair<std::pair<uint32_t, uint32_t>, uint32_t> > &location) {} // only useful for mirage, obtain free locations in each skew
 
   // hook interface for replacer state update, Monitor and delay estimation
   virtual void hook_read(uint64_t addr, uint32_t ai, uint32_t s, uint32_t w, bool hit, uint64_t *delay) = 0;

--- a/cache/mirage.hpp
+++ b/cache/mirage.hpp
@@ -242,7 +242,7 @@ private:
 // EnMon: whether to enable monitoring
 // EnableRelocation : whether to enable relocation
 template<int IW, int NW, int EW, int P, int RW, typename MT, typename DT, typename DTMT, typename MIDX, typename DIDX, typename MRPC, typename DRPC, typename DLY, bool EnMon, bool EnableRelocation, 
-         typename = typename std::enable_if<std::is_base_of<CMMetadataBase, MT>::value>::type,  // MT <- CMMetadataBase
+         typename = typename std::enable_if<std::is_base_of<MirageMetadataMSIBase, MT>::value>::type,  // MT <- MirageMetadataMSIBase
          typename = typename std::enable_if<std::is_base_of<CMDataBase, DT>::value || std::is_void<DT>::value>::type, // DT <- CMDataBase or void
          typename = typename std::enable_if<std::is_base_of<CMMetadataBase, DTMT>::value>::type,  // DTMT <- MirageDataMeta
          typename = typename std::enable_if<std::is_base_of<IndexFuncBase, MIDX>::value>::type,  // MIDX <- IndexFuncBase
@@ -438,7 +438,7 @@ public:
 //   no support for reverse probe as if there is no internal cache
 //   or the interl cache does not participate in the coherence communication
 template<typename MT, typename DT, typename Policy, bool isLLC, 
-         typename = typename std::enable_if<std::is_base_of<MirageMetadataMSIBase, MT>::value>::type, // MT <- CMMetadataBase
+         typename = typename std::enable_if<std::is_base_of<MirageMetadataMSIBase, MT>::value>::type, // MT <- MirageMetadataMSIBase
          typename = typename std::enable_if<std::is_base_of<CMDataBase, DT>::value || std::is_void<DT>::value>::type> // DT <- CMDataBase or void
 class MirageInnerPortMSIUncached : public InnerCohPortBase
 {
@@ -468,7 +468,7 @@ public:
       MirageDataMeta *data_meta, *data_mmeta;
       uint32_t m_ai, m_s, m_w, m_ds, m_dw;
       uint64_t addrr = addr;
-      this->cache->replace(addr, &ai, &s, &w);
+      cache->replace(addr, &ai, &s, &w);
       meta = static_cast<MirageMetadataMSIBase *>(cache->access(ai, s, w));
       if(meta->is_valid()){
         cache->cuckoo_search(&ai, &s, &w, meta, addr_stack);

--- a/config/mirage.def
+++ b/config/mirage.def
@@ -13,14 +13,14 @@ const LLCWE = 6;         // LLC every skew 6 ways extra
 const LLCWS = 14;        // LLC every skew 8 + 6 = 14 ways all
 const LLCTagOffset = 6;  // random index
 const LLCWD = 16;        // LLC data ways is LLCPartitionN(2) * LLCWN(8) = 16 
-const LLCRW = 0;         // Cuckoo max relocation 
+const LLCRW = 2;         // Cuckoo max relocation 
 
 // optimal options
 const EnableDelay      = false;  // disable delay estimation
 const EnableMonitor    = false;  // disable pfc monitoring
-const EnableRelocation = false;  // disable cuckoo relocation
+const EnableRelocation = true;  // disable cuckoo relocation
 
-type data_type         = void;
+type data_type         = Data64B();
 
 // initiate the L1 cache
 type l1_metadata_type   = MetadataMSI(AddrWidth, L1IW, L1TagOffset);
@@ -42,9 +42,9 @@ type llc_d_indexer_type  = IndexRandom(LLCIW, BlockOffset);
 type llc_m_replacer_type = ReplaceLRU(LLCWS, LLCWN);
 type llc_d_replacer_type = ReplaceCompleteRandom(LLCIW, LLCWD);
 type llc_delay_type      = void;
-type llc_type            = CacheMirage(LLCIW, LLCWN, LLCWE, LLCPartitionN, llc_metadata_type, data_type, llc_datameta_type, llc_m_indexer_type, llc_d_indexer_type, llc_m_replacer_type, llc_d_replacer_type, llc_delay_type, EnableMonitor);
+type llc_type            = CacheMirage(LLCIW, LLCWN, LLCWE, LLCPartitionN, LLCRW, llc_metadata_type, data_type, llc_datameta_type, llc_m_indexer_type, llc_d_indexer_type, llc_m_replacer_type, llc_d_replacer_type, llc_delay_type, EnableMonitor, EnableRelocation);
 type llc_policy          = MirageMSIPolicy();
-type llc_inner_type      = MirageInnerPortMSIBroadcast(llc_metadata_type, data_type, llc_policy, true, EnableRelocation, LLCRW);
+type llc_inner_type      = MirageInnerPortMSIBroadcast(llc_metadata_type, data_type, llc_policy, true);
 type llc_outer_type      = MirageOuterPortMSIUncached(llc_metadata_type, data_type, llc_policy);
 type llc_cache_type      = CoherentCacheNorm(llc_type, llc_outer_type, llc_inner_type);
 create llc = llc_cache_type[1]; // 1 shared llc slices

--- a/dsl/type_description.cpp
+++ b/dsl/type_description.cpp
@@ -198,8 +198,8 @@ void TypeCacheNorm::emit(std::ofstream &file) {
 }
 
 bool TypeCacheMirage::set(std::list<std::string> &values) {
-  if(values.size() != 13) {
-    std::cerr << "[Mismatch] " << tname << " needs 13 parameters!" << std::endl;
+  if(values.size() != 15) {
+    std::cerr << "[Mismatch] " << tname << " needs 15 parameters!" << std::endl;
     return false;
   }
   auto it = values.begin();
@@ -207,6 +207,7 @@ bool TypeCacheMirage::set(std::list<std::string> &values) {
   if(!codegendb.parse_int(*it, NW)) return false; it++;
   if(!codegendb.parse_int(*it, EW)) return false; it++;
   if(!codegendb.parse_int(*it, P)) return false; it++;
+  if(!codegendb.parse_int(*it, RW)) return false; it++;
   MT   = *it; if(!this->check(tname, "MT", *it, "CMMetadataBase", false)) return false; it++;
   DT   = *it; if(!this->check(tname, "DT", *it, "CMDataBase", true)) return false; it++;
   MTDT = *it; if(!this->check(tname, "MTDT", *it, "CMMetadataBase", false)) return false; it++;
@@ -216,11 +217,12 @@ bool TypeCacheMirage::set(std::list<std::string> &values) {
   DRPC = *it; if(!this->check(tname, "DRPC", *it, "ReplaceFuncBase", false)) return false; it++;
   DLY  = *it; if(!this->check(tname, "DLY", *it, "DelayBase", true)) return false; it++;
   if(!codegendb.parse_bool(*it, EnMon)) return false; it++;
+  if(!codegendb.parse_bool(*it, EnableRelocation)) return false; it++;
   return true;
 }
  
 void TypeCacheMirage::emit(std::ofstream &file) {
-  file << "typedef " << tname << "<" << IW << "," << NW << "," << EW << "," << P << "," << MT << "," << DT << "," << MTDT << "," << MIDX << "," << DIDX << "," << MRPC << "," << DRPC << "," << DLY << "," << EnMon << "> " << this->name << ";" << std::endl;
+  file << "typedef " << tname << "<" << IW << "," << NW << "," << EW << "," << P << "," << RW <<  "," << MT << "," << DT << "," << MTDT << "," << MIDX << "," << DIDX << "," << MRPC << "," << DRPC << "," << DLY << "," << EnMon << "," << EnableRelocation << "> " << this->name << ";" << std::endl;
 }
 
 void TypeCacheMirage::emit_header() { codegendb.add_header("cache/mirage.hpp"); }
@@ -384,8 +386,8 @@ void TypeMirageOuterPortMSI::emit(std::ofstream &file) {
 void TypeMirageOuterPortMSI::emit_header() { codegendb.add_header("cache/msi.hpp"); }
 
 bool TypeMirageInnerPortMSIUncached::set(std::list<std::string> &values) {
-  if(values.size() != 6) {
-    std::cerr << "[Mismatch] " << tname << " needs 6 parameters!" << std::endl;
+  if(values.size() != 4) {
+    std::cerr << "[Mismatch] " << tname << " needs 4 parameters!" << std::endl;
     return false;
   }
   auto it = values.begin();
@@ -393,20 +395,18 @@ bool TypeMirageInnerPortMSIUncached::set(std::list<std::string> &values) {
   DT  = *it; if(!this->check(tname, "DT", *it, "CMDataBase", true)) return false; it++;
   Policy = *it; it++;
   if(!codegendb.parse_bool(*it, isLLC)) return false; it++;
-  if(!codegendb.parse_bool(*it, enableRelocation)) return false; it++;
-  if(!codegendb.parse_int(*it, RW)) return false; it++;
   return true;
 }
   
 void TypeMirageInnerPortMSIUncached::emit(std::ofstream &file) {
-  file << "typedef " << tname << "<" << MT << "," << DT << "," << Policy << "," << isLLC << "," << enableRelocation << "," << RW << "> " << this->name << ";" << std::endl;
+  file << "typedef " << tname << "<" << MT << "," << DT << "," << Policy << "," << isLLC << "> " << this->name << ";" << std::endl;
 }    
 
 void TypeMirageInnerPortMSIUncached::emit_header() { codegendb.add_header("cache/mirage.hpp"); }
 
 bool TypeMirageInnerPortMSIBroadcast::set(std::list<std::string> &values) {
-  if(values.size() != 6) {
-    std::cerr << "[Mismatch] " << tname << " needs 6 parameters!" << std::endl;
+  if(values.size() != 4) {
+    std::cerr << "[Mismatch] " << tname << " needs 4 parameters!" << std::endl;
     return false;
   }
   auto it = values.begin();
@@ -414,13 +414,11 @@ bool TypeMirageInnerPortMSIBroadcast::set(std::list<std::string> &values) {
   DT  = *it; if(!this->check(tname, "DT", *it, "CMDataBase", true)) return false; it++;
   Policy = *it; it++;
   if(!codegendb.parse_bool(*it, isLLC)) return false; it++;
-  if(!codegendb.parse_bool(*it, enableRelocation)) return false; it++;
-  if(!codegendb.parse_int(*it, RW)) return false; it++;
   return true;
 }
   
 void TypeMirageInnerPortMSIBroadcast::emit(std::ofstream &file) {
-  file << "typedef " << tname << "<" << MT << "," << DT << "," << Policy << "," << isLLC << "," << enableRelocation << "," << RW << "> " << this->name << ";" << std::endl;
+  file << "typedef " << tname << "<" << MT << "," << DT << "," << Policy << "," << isLLC << "> " << this->name << ";" << std::endl;
 }    
 
 void TypeMirageInnerPortMSIBroadcast::emit_header() { codegendb.add_header("cache/mirage.hpp"); }
@@ -436,13 +434,11 @@ bool TypeMirageCoreInterfaceMSI::set(std::list<std::string> &values) {
   Policy = *it; it++;
   if(!codegendb.parse_bool(*it, enableDelay)) return false; it++;
   if(!codegendb.parse_bool(*it, isLLC)) return false; it++;
-  if(!codegendb.parse_bool(*it, enableRelocation)) return false; it++;
-  if(!codegendb.parse_int(*it, RW)) return false; it++;
   return true;
 }
   
 void TypeMirageCoreInterfaceMSI::emit(std::ofstream &file) {
-  file << "typedef " << tname << "<" << MT << "," << DT << "," << Policy << "," << enableDelay << "," << isLLC << "," << enableRelocation << "," << RW << "> " << this->name << ";" << std::endl;
+  file << "typedef " << tname << "<" << MT << "," << DT << "," << Policy << "," << enableDelay << "," << isLLC << "> " << this->name << ";" << std::endl;
 }    
 
 void TypeMirageCoreInterfaceMSI::emit_header() { codegendb.add_header("cache/mirage.hpp"); }

--- a/dsl/type_description.hpp
+++ b/dsl/type_description.hpp
@@ -178,7 +178,7 @@ public:
 
 class TypeCacheMirage : public TypeCacheBase
 {
-  int IW, NW, EW, P; std::string MT, DT, MTDT, MIDX, DIDX, MRPC, DRPC, DLY; bool EnMon;
+  int IW, NW, EW, P, RW; std::string MT, DT, MTDT, MIDX, DIDX, MRPC, DRPC, DLY; bool EnMon, EnableRelocation;
   const std::string tname;
 public:
   TypeCacheMirage(const std::string &name) : TypeCacheBase(name), tname("CacheMirage") {}
@@ -296,7 +296,7 @@ public:
 
 class TypeMirageInnerPortMSIUncached : public TypeInnerCohPortBase
 {
-  std::string MT, DT, Policy; bool isLLC, enableRelocation; int RW;
+  std::string MT, DT, Policy; bool isLLC;
   const std::string tname;
 public:
   TypeMirageInnerPortMSIUncached(const std::string &name) : TypeInnerCohPortBase(name), tname("MirageInnerPortMSIUncached") {}
@@ -307,7 +307,7 @@ public:
 
 class TypeMirageInnerPortMSIBroadcast : public TypeInnerCohPortBase
 {
-  std::string MT, DT, Policy; bool isLLC, enableRelocation; int RW;
+  std::string MT, DT, Policy; bool isLLC;
   const std::string tname;
 public:
   TypeMirageInnerPortMSIBroadcast(const std::string &name) : TypeInnerCohPortBase(name), tname("MirageInnerPortMSIBroadcast") {}
@@ -318,7 +318,7 @@ public:
 
 class TypeMirageCoreInterfaceMSI : public TypeCoreInterfaceBase
 {
-  std::string MT, DT, Policy; bool enableDelay, isLLC, enableRelocation; int RW;
+  std::string MT, DT, Policy; bool enableDelay, isLLC;
   const std::string tname;
 public:
   TypeMirageCoreInterfaceMSI(const std::string &name) : TypeCoreInterfaceBase(name), tname("MirageCoreInterfaceMSI") {}


### PR DESCRIPTION
You really should not mess up the base class definition with Mirage specific functions. If every extension does this at ease, the base class will eventually become a garbage bin with numerous unknown methods from unknown extensions!

Beside, I see no reason or obvious obstacle that forced you to do so.

For the repalcer, replacer related logic should be incorporated into the repalcer itself. Once the replace function is called, the selected partition, set and way should be chosen, rather than leaving some operations outside and asking other classes to do the rest.

It is not finished yet and I will go back to clean it up further. 