### PR TITLE
Significantly simplify the way in defining cache types

### DIFF
--- a/cache/exclusive.hpp
+++ b/cache/exclusive.hpp
@@ -80,7 +80,7 @@ public:
   }
 };
 
-template<typename MT, bool isLLC> requires C_DERIVE(MT, MetadataDirectoryBase)
+template<typename MT, bool EnDir, bool isLLC> requires C_DERIVE(MT, MetadataDirectoryBase) && EnDir
 class ExclusiveMESIPolicy : public ExclusiveMSIPolicy<MT, true, isLLC>
 {
   typedef ExclusiveMSIPolicy<MT, true, isLLC> PolicyT;
@@ -188,13 +188,13 @@ public:
 template<int IW, int NW, typename MT, typename DT, typename IDX, typename RPC, typename DLY, bool EnMon>
 using CacheNormExclusiveBroadcast = CacheSkewedExclusive<IW, NW, 0, 1, MT, DT, IDX, RPC, ReplaceRandom<1,1>, DLY, EnMon, false>;
 
-class ExclusiveInnerPortUncachedBroadcast : public InnerCohPortUncached
+class ExclusiveInnerCohPortUncachedBroadcast : public InnerCohPortUncached
 {
 protected:
   using InnerCohPortBase::cache;
 public:
-  ExclusiveInnerPortUncachedBroadcast(CohPolicyBase *policy) : InnerCohPortUncached(policy) {}
-  virtual ~ExclusiveInnerPortUncachedBroadcast() {}
+  ExclusiveInnerCohPortUncachedBroadcast(CohPolicyBase *policy) : InnerCohPortUncached(policy) {}
+  virtual ~ExclusiveInnerCohPortUncachedBroadcast() {}
 
   virtual void acquire_resp(uint64_t addr, CMDataBase *data_inner, CMMetadataBase *meta_inner, coh_cmd_t cmd, uint64_t *delay) {
     auto [meta, data, ai, s, w, hit] = access_line(addr, cmd, delay);
@@ -335,7 +335,7 @@ protected:
 
 };
 
-typedef InnerCohPortT<ExclusiveInnerPortUncachedBroadcast> ExclusiveInnerPortBroadcast;
+typedef InnerCohPortT<ExclusiveInnerCohPortUncachedBroadcast> ExclusiveInnerCohPortBroadcast;
 
 // Norm Exclusive Cache with Extened Directory
 // Assume extended directory meta is always supported when directory is used
@@ -346,13 +346,13 @@ typedef InnerCohPortT<ExclusiveInnerPortUncachedBroadcast> ExclusiveInnerPortBro
 template<int IW, int NW, int DW, typename MT, typename DT, typename IDX, typename RPC, typename DRPC, typename DLY, bool EnMon>
 using CacheNormExclusiveDirectory = CacheSkewedExclusive<IW, NW, DW, 1, MT, DT, IDX, RPC, DRPC, DLY, EnMon, true>;
 
-class ExclusiveInnerPortUncachedDirectory : public InnerCohPortUncached
+class ExclusiveInnerCohPortUncachedDirectory : public InnerCohPortUncached
 {
 protected:
   using InnerCohPortBase::cache;
 public:
-  ExclusiveInnerPortUncachedDirectory(CohPolicyBase *policy) : InnerCohPortUncached(policy) {}
-  virtual ~ExclusiveInnerPortUncachedDirectory() {}
+  ExclusiveInnerCohPortUncachedDirectory(CohPolicyBase *policy) : InnerCohPortUncached(policy) {}
+  virtual ~ExclusiveInnerCohPortUncachedDirectory() {}
 
   virtual void acquire_resp(uint64_t addr, CMDataBase *data_inner, CMMetadataBase *meta_inner, coh_cmd_t outer_cmd, uint64_t *delay) {
     auto [meta, data, ai, s, w, hit] = access_line(addr, outer_cmd, delay);
@@ -504,7 +504,7 @@ protected:
 
 };
 
-typedef InnerCohPortT<ExclusiveInnerPortUncachedDirectory> ExclusiveInnerPortDirectory;
+typedef InnerCohPortT<ExclusiveInnerCohPortUncachedDirectory> ExclusiveInnerCohPortDirectory;
 
 
 template<class OPUC> requires C_DERIVE(OPUC, OuterCohPortUncached)
@@ -609,15 +609,15 @@ public:
 typedef ExclusiveOuterCohPortDirectoryT<OuterCohPortUncached> ExclusiveOuterCohPortDirectory;
 
 template<typename CT>
-using ExclusiveL2CacheBroadcast = CoherentCacheNorm<CT, ExclusiveOuterCohPortBroadcast, ExclusiveInnerPortBroadcast>;
+using ExclusiveL2CacheBroadcast = CoherentCacheNorm<CT, ExclusiveOuterCohPortBroadcast, ExclusiveInnerCohPortBroadcast>;
 
 template<typename CT>
-using ExclusiveLLCBroadcast = CoherentCacheNorm<CT, OuterCohPortUncached, ExclusiveInnerPortBroadcast>;
+using ExclusiveLLCBroadcast = CoherentCacheNorm<CT, OuterCohPortUncached, ExclusiveInnerCohPortBroadcast>;
 
 template<typename CT>
-using ExclusiveL2CacheDirectory = CoherentCacheNorm<CT, ExclusiveOuterCohPortDirectory, ExclusiveInnerPortDirectory>;
+using ExclusiveL2CacheDirectory = CoherentCacheNorm<CT, ExclusiveOuterCohPortDirectory, ExclusiveInnerCohPortDirectory>;
 
 template<typename CT>
-using ExclusiveLLCDirectory = CoherentCacheNorm<CT, OuterCohPortUncached, ExclusiveInnerPortDirectory>;
+using ExclusiveLLCDirectory = CoherentCacheNorm<CT, OuterCohPortUncached, ExclusiveInnerCohPortDirectory>;
 
 #endif

--- a/cache/mesi.hpp
+++ b/cache/mesi.hpp
@@ -19,7 +19,7 @@ private:
 template <int AW, int IW, int TOfst>
 using MetadataMESIDirectory = MetadataDirectory<AW, IW, TOfst, MetadataMESIBase<MetadataDirectoryBase> >;
 
-template<typename MT, bool isLLC> requires C_DERIVE(MT, MetadataDirectoryBase)
+template<typename MT, bool isL1, bool isLLC> requires C_DERIVE(MT, MetadataDirectoryBase) && !isL1
 class MESIPolicy : public MSIPolicy<MT, false, isLLC>
 {
   typedef MSIPolicy<MT, false, isLLC> PolicyT;

--- a/regression/c1-l1.cpp
+++ b/regression/c1-l1.cpp
@@ -26,8 +26,7 @@ int main() {
     } else if(rw) {
       core->write(addr, wdata, nullptr);
     } else {
-      auto rdata = static_cast<const Data64B *>(core->read(addr, nullptr));
-      if(!tgen.check(addr, rdata)) return 1; // test failed!
+      if(!tgen.check(addr, core->read(addr, nullptr))) return 1; // test failed!
     }
   }
 

--- a/regression/c1-l1.cpp
+++ b/regression/c1-l1.cpp
@@ -8,7 +8,7 @@
 int main() {
   auto cache = cache_gen_l1<4, 4, Data64B, MetadataBroadcastBase, ReplaceFIFO, MSIPolicy, true, true, void, true>(1, "l1d");
   auto l1d = cache[0];
-  auto core = get_l1_core_interface(cache)[0];
+  auto core = get_l1_core_interface(cache);
   auto mem = new SimpleMemoryModel<Data64B,void,true>("mem");
   l1d->outer->connect(mem, mem->connect(l1d->outer));
 
@@ -17,18 +17,5 @@ int main() {
   mem->attach_monitor(&tracer);
 
   RegressionGen<1, false, AddrN, 0, Data64B> tgen;
-
-  for(int i=0; i<TestN; i++) {
-    auto [addr, wdata, rw, nc, ic, flush] = tgen.gen();
-    if(flush) {
-      core->flush(addr, nullptr);
-      core->write(addr, wdata, nullptr);
-    } else if(rw) {
-      core->write(addr, wdata, nullptr);
-    } else {
-      if(!tgen.check(addr, core->read(addr, nullptr))) return 1; // test failed!
-    }
-  }
-
-  return 0;
+  return tgen.run(TestN, core, core);
 }

--- a/regression/c1-l1.cpp
+++ b/regression/c1-l1.cpp
@@ -1,42 +1,22 @@
-#include "cache/cache.hpp"
-#include "cache/index.hpp"
-#include "cache/replace.hpp"
-#include "cache/coherence.hpp"
-#include "cache/msi.hpp"
 #include "cache/memory.hpp"
+#include "util/cache_type.hpp"
 #include "util/regression.hpp"
 
 #define AddrN 128
 #define TestN 512
 
-#define L1IW 4
-#define L1WN 4
-#define L1Toff (L1IW + 6)
-
-typedef Data64B data_type;
-typedef MetadataMSIBroadcast<48, L1IW, L1Toff> l1_metadata_type;
-typedef IndexNorm<L1IW,6> l1_indexer_type;
-typedef ReplaceFIFO<L1IW,L1WN,1> l1_replacer_type;
-typedef void l1_delay_type;
-typedef CacheNorm<L1IW,L1WN,l1_metadata_type,data_type,l1_indexer_type,l1_replacer_type,void,true> l1_type;
-typedef MSIPolicy<l1_metadata_type,1,1> l1_policy_type;
-
-typedef OuterCohPortUncached memory_port_type;
-typedef CoherentL1CacheNorm<l1_type,memory_port_type> l1_cache_type;
-typedef SimpleMemoryModel<data_type,void,true> memory_type;
-
 int main() {
-  auto l1_policy = new l1_policy_type();
-  auto l1d = new l1_cache_type(l1_policy, "l1d");
-  auto core = static_cast<CoreInterface *>(l1d->inner);
-  auto mem = new memory_type("mem");
+  auto cache = cache_gen_l1<4, 4, Data64B, MetadataBroadcastBase, ReplaceFIFO, MSIPolicy, true, true, void, true>(1, "l1d");
+  auto l1d = cache[0];
+  auto core = get_l1_core_interface(cache)[0];
+  auto mem = new SimpleMemoryModel<Data64B,void,true>("mem");
   l1d->outer->connect(mem, mem->connect(l1d->outer));
 
   SimpleTracer tracer(true);
   l1d->attach_monitor(&tracer);
   mem->attach_monitor(&tracer);
 
-  RegressionGen<1, false, AddrN, 0, data_type> tgen;
+  RegressionGen<1, false, AddrN, 0, Data64B> tgen;
 
   for(int i=0; i<TestN; i++) {
     auto [addr, wdata, rw, nc, ic, flush] = tgen.gen();
@@ -46,7 +26,7 @@ int main() {
     } else if(rw) {
       core->write(addr, wdata, nullptr);
     } else {
-      auto rdata = static_cast<const data_type *>(core->read(addr, nullptr));
+      auto rdata = static_cast<const Data64B *>(core->read(addr, nullptr));
       if(!tgen.check(addr, rdata)) return 1; // test failed!
     }
   }

--- a/regression/c2-l2-exc-mesi.cpp
+++ b/regression/c2-l2-exc-mesi.cpp
@@ -35,20 +35,5 @@ int main() {
   mem->attach_monitor(&tracer);
 
   RegressionGen<NCore, true, PAddrN, SAddrN, Data64B> tgen;
-
-  for(int i=0; i<TestN; i++) {
-    auto [addr, wdata, rw, nc, ic, flush] = tgen.gen();
-    if(flush) {
-      if(flush > 1) for( auto ci:core_inst) ci->flush(addr, nullptr); // shared instruction, flush all cores
-      else          core_inst[nc]->flush(addr, nullptr);
-      core_data[nc]->write(addr, wdata, nullptr);
-    } else if(rw) {
-      core_data[nc]->write(addr, wdata, nullptr);
-    } else {
-      auto rdata = ic ? core_inst[nc]->read(addr, nullptr) : core_data[nc]->read(addr, nullptr);
-      if(!tgen.check(addr, rdata)) return 1; // test failed!
-    }
-  }
-
-  return 0;
+  return tgen.run(TestN, core_inst, core_data);
 }

--- a/regression/c2-l2-exc-mesi.cpp
+++ b/regression/c2-l2-exc-mesi.cpp
@@ -45,9 +45,7 @@ int main() {
     } else if(rw) {
       core_data[nc]->write(addr, wdata, nullptr);
     } else {
-      const Data64B *rdata;
-      if(ic) rdata = static_cast<const Data64B *>(core_inst[nc]->read(addr, nullptr));
-      else   rdata = static_cast<const Data64B *>(core_data[nc]->read(addr, nullptr));
+      auto rdata = ic ? core_inst[nc]->read(addr, nullptr) : core_data[nc]->read(addr, nullptr);
       if(!tgen.check(addr, rdata)) return 1; // test failed!
     }
   }

--- a/regression/c2-l2-exc-mesi.cpp
+++ b/regression/c2-l2-exc-mesi.cpp
@@ -1,9 +1,5 @@
-#include "cache/exclusive.hpp"
-#include "cache/mesi.hpp"
-#include "cache/index.hpp"
-#include "cache/replace.hpp"
 #include "cache/memory.hpp"
-#include "util/random.hpp"
+#include "util/cache_type.hpp"
 #include "util/regression.hpp"
 
 #define PAddrN 128
@@ -13,47 +9,18 @@
 
 #define L1IW 4
 #define L1WN 4
-#define L1Toff (L1IW + 6)
 
 #define L2IW 5
 #define L2WN 8
 #define L2DW 4
-#define L2Toff (L2IW + 6)
-
-typedef Data64B data_type;
-typedef MetadataMSIBroadcast<48, L1IW, L1Toff> l1_metadata_type;
-typedef IndexNorm<L1IW,6> l1_indexer_type;
-typedef ReplaceLRU<L1IW,L1WN,true> l1_replacer_type;
-typedef CacheNorm<L1IW,L1WN,l1_metadata_type,data_type,l1_indexer_type,l1_replacer_type,void,true> l1_type;
-typedef MSIPolicy<l1_metadata_type,true,false> l1_policy_type;
-typedef CoherentL1CacheNorm<l1_type, OuterCohPortUncached> l1i_cache_type;
-typedef CoherentL1CacheNorm<l1_type> l1d_cache_type;
-
-typedef MetadataMESIDirectory<48, L2IW, L2Toff> l2_metadata_type;
-typedef IndexNorm<L2IW,6> l2_indexer_type;
-typedef ReplaceSRRIP<L2IW,L2WN,true> l2_replacer_type;
-typedef ReplaceLRU<L2IW,L2DW,true> l2_ext_replacer_type;
-typedef CacheNormExclusiveDirectory<L2IW,L2WN,L2DW,l2_metadata_type,data_type,l2_indexer_type,l2_replacer_type,l2_ext_replacer_type,void,true> l2_type;
-typedef ExclusiveMESIPolicy<l2_metadata_type,true> l2_policy_type;
-
-typedef OuterCohPortUncached memory_port_type;
-typedef ExclusiveLLCDirectory<l2_type> l2_cache_type;
-typedef SimpleMemoryModel<data_type,void,true> memory_type;
 
 int main() {
-  auto l1_policy = new l1_policy_type();
-  std::vector<l1i_cache_type *> l1i(NCore);
-  std::vector<l1d_cache_type *> l1d(NCore);
-  std::vector<CoreInterface *>  core_inst(NCore), core_data(NCore);
-  for(int i=0; i<NCore; i++) {
-    l1i[i] = new l1i_cache_type(l1_policy, "l1i-" + std::to_string(i));
-    l1d[i] = new l1d_cache_type(l1_policy, "l1d-" + std::to_string(i));
-    core_inst[i] = static_cast<CoreInterface *>(l1i[i]->inner);
-    core_data[i] = static_cast<CoreInterface *>(l1d[i]->inner);
-  }
-  auto l2_policy = new l2_policy_type();
-  auto l2 = new l2_cache_type(l2_policy, "l2");
-  auto mem = new memory_type("mem");
+  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, false, void, true>(NCore, "l1d");
+  auto core_data = get_l1_core_interface(l1d);
+  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, true, void, true>(NCore, "l1i");
+  auto core_inst = get_l1_core_interface(l1i);
+  auto l2 = cache_gen_l2_exc<L2IW, L2WN, L2DW, Data64B, MetadataDirectoryBase, ReplaceSRRIP, ReplaceLRU, MESIPolicy, true, void, true>(1, "l2")[0];
+  auto mem = new SimpleMemoryModel<Data64B,void,true>("mem");
   SimpleTracer tracer(true);
 
   for(int i=0; i<NCore; i++) {
@@ -67,7 +34,7 @@ int main() {
   l2->attach_monitor(&tracer);
   mem->attach_monitor(&tracer);
 
-  RegressionGen<NCore, true, PAddrN, SAddrN, data_type> tgen;
+  RegressionGen<NCore, true, PAddrN, SAddrN, Data64B> tgen;
 
   for(int i=0; i<TestN; i++) {
     auto [addr, wdata, rw, nc, ic, flush] = tgen.gen();
@@ -78,9 +45,9 @@ int main() {
     } else if(rw) {
       core_data[nc]->write(addr, wdata, nullptr);
     } else {
-      const data_type *rdata;
-      if(ic) rdata = static_cast<const data_type *>(core_inst[nc]->read(addr, nullptr));
-      else   rdata = static_cast<const data_type *>(core_data[nc]->read(addr, nullptr));
+      const Data64B *rdata;
+      if(ic) rdata = static_cast<const Data64B *>(core_inst[nc]->read(addr, nullptr));
+      else   rdata = static_cast<const Data64B *>(core_data[nc]->read(addr, nullptr));
       if(!tgen.check(addr, rdata)) return 1; // test failed!
     }
   }

--- a/regression/c2-l2-exc-mi.cpp
+++ b/regression/c2-l2-exc-mi.cpp
@@ -44,9 +44,7 @@ int main() {
     } else if(rw) {
       core_data[nc]->write(addr, wdata, nullptr);
     } else {
-      const Data64B *rdata;
-      if(ic) rdata = static_cast<const Data64B *>(core_inst[nc]->read(addr, nullptr));
-      else   rdata = static_cast<const Data64B *>(core_data[nc]->read(addr, nullptr));
+      auto rdata = ic ? core_inst[nc]->read(addr, nullptr) : core_data[nc]->read(addr, nullptr);
       if(!tgen.check(addr, rdata)) return 1; // test failed!
     }
   }

--- a/regression/c2-l2-exc-mi.cpp
+++ b/regression/c2-l2-exc-mi.cpp
@@ -34,20 +34,5 @@ int main() {
   mem->attach_monitor(&tracer);
 
   RegressionGen<NCore, true, PAddrN, SAddrN, Data64B> tgen;
-
-  for(int i=0; i<TestN; i++) {
-    auto [addr, wdata, rw, nc, ic, flush] = tgen.gen();
-    if(flush) {
-      if(flush > 1) for( auto ci:core_inst) ci->flush(addr, nullptr); // shared instruction, flush all cores
-      else          core_inst[nc]->flush(addr, nullptr);
-      core_data[nc]->write(addr, wdata, nullptr);
-    } else if(rw) {
-      core_data[nc]->write(addr, wdata, nullptr);
-    } else {
-      auto rdata = ic ? core_inst[nc]->read(addr, nullptr) : core_data[nc]->read(addr, nullptr);
-      if(!tgen.check(addr, rdata)) return 1; // test failed!
-    }
-  }
-
-  return 0;
+  return tgen.run(TestN, core_inst, core_data);
 }

--- a/regression/c2-l2-exc-mi.cpp
+++ b/regression/c2-l2-exc-mi.cpp
@@ -1,9 +1,5 @@
-#include "cache/exclusive.hpp"
-#include "cache/mi.hpp"
-#include "cache/index.hpp"
-#include "cache/replace.hpp"
 #include "cache/memory.hpp"
-#include "util/random.hpp"
+#include "util/cache_type.hpp"
 #include "util/regression.hpp"
 
 #define PAddrN 128
@@ -13,49 +9,17 @@
 
 #define L1IW 4
 #define L1WN 4
-#define L1Toff (L1IW + 6)
 
 #define L2IW 5
 #define L2WN 8
-#define L2Toff (L2IW + 6)
-
-typedef Data64B data_type;
-typedef MetadataMSIBroadcast<48, L1IW, L1Toff> l1i_metadata_type;
-typedef MetadataMIBroadcast<48, L1IW, L1Toff> l1d_metadata_type;
-typedef IndexNorm<L1IW,6> l1_indexer_type;
-typedef ReplaceLRU<L1IW,L1WN,1> l1_replacer_type;
-typedef CacheNorm<L1IW,L1WN,l1i_metadata_type,data_type,l1_indexer_type,l1_replacer_type,void,true> l1i_type;
-typedef CacheNorm<L1IW,L1WN,l1d_metadata_type,data_type,l1_indexer_type,l1_replacer_type,void,true> l1d_type;
-typedef MSIPolicy<l1i_metadata_type,true,false> l1i_policy_type;
-typedef MIPolicy<l1d_metadata_type,true,false> l1d_policy_type;
-typedef CoherentL1CacheNorm<l1i_type, OuterCohPortUncached> l1i_cache_type;
-typedef CoherentL1CacheNorm<l1d_type> l1d_cache_type;
-
-typedef MetadataMSIBroadcast<48, L2IW, L2Toff> l2_metadata_type;
-typedef IndexNorm<L2IW,6> l2_indexer_type;
-typedef ReplaceSRRIP<L2IW,L2WN,1> l2_replacer_type;
-typedef CacheNormExclusiveBroadcast<L2IW,L2WN,l2_metadata_type,data_type,l2_indexer_type,l2_replacer_type,void,true> l2_type;
-typedef ExclusiveMSIPolicy<l2_metadata_type,false,true> l2_policy_type;
-
-typedef OuterCohPortUncached memory_port_type;
-typedef ExclusiveLLCBroadcast<l2_type> l2_cache_type;
-typedef SimpleMemoryModel<data_type,void,true> memory_type;
 
 int main() {
-  auto l1i_policy = new l1i_policy_type();
-  auto l1d_policy = new l1d_policy_type();
-  std::vector<l1i_cache_type *> l1i(NCore);
-  std::vector<l1d_cache_type *> l1d(NCore);
-  std::vector<CoreInterface *>  core_inst(NCore), core_data(NCore);
-  for(int i=0; i<NCore; i++) {
-    l1i[i] = new l1i_cache_type(l1i_policy, "l1i-" + std::to_string(i));
-    l1d[i] = new l1d_cache_type(l1d_policy, "l1d-" + std::to_string(i));
-    core_inst[i] = static_cast<CoreInterface *>(l1i[i]->inner);
-    core_data[i] = static_cast<CoreInterface *>(l1d[i]->inner);
-  }
-  auto l2_policy = new l2_policy_type();
-  auto l2 = new l2_cache_type(l2_policy, "l2");
-  auto mem = new memory_type("mem");
+  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MIPolicy, false, false, void, true>(NCore, "l1d");
+  auto core_data = get_l1_core_interface(l1d);
+  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, true, void, true>(NCore, "l1i");
+  auto core_inst = get_l1_core_interface(l1i);
+  auto l2 = cache_gen_l2_exc<L2IW, L2WN, Data64B, MetadataBroadcastBase, ReplaceSRRIP, MSIPolicy, true, void, true>(1, "l2")[0];
+  auto mem = new SimpleMemoryModel<Data64B,void,true>("mem");
   SimpleTracer tracer(true);
 
   for(int i=0; i<NCore; i++) {
@@ -69,7 +33,7 @@ int main() {
   l2->attach_monitor(&tracer);
   mem->attach_monitor(&tracer);
 
-  RegressionGen<NCore, true, PAddrN, SAddrN, data_type> tgen;
+  RegressionGen<NCore, true, PAddrN, SAddrN, Data64B> tgen;
 
   for(int i=0; i<TestN; i++) {
     auto [addr, wdata, rw, nc, ic, flush] = tgen.gen();
@@ -80,9 +44,9 @@ int main() {
     } else if(rw) {
       core_data[nc]->write(addr, wdata, nullptr);
     } else {
-      const data_type *rdata;
-      if(ic) rdata = static_cast<const data_type *>(core_inst[nc]->read(addr, nullptr));
-      else   rdata = static_cast<const data_type *>(core_data[nc]->read(addr, nullptr));
+      const Data64B *rdata;
+      if(ic) rdata = static_cast<const Data64B *>(core_inst[nc]->read(addr, nullptr));
+      else   rdata = static_cast<const Data64B *>(core_data[nc]->read(addr, nullptr));
       if(!tgen.check(addr, rdata)) return 1; // test failed!
     }
   }

--- a/regression/c2-l2-exc.cpp
+++ b/regression/c2-l2-exc.cpp
@@ -44,9 +44,7 @@ int main() {
     } else if(rw) {
       core_data[nc]->write(addr, wdata, nullptr);
     } else {
-      const Data64B *rdata;
-      if(ic) rdata = static_cast<const Data64B *>(core_inst[nc]->read(addr, nullptr));
-      else   rdata = static_cast<const Data64B *>(core_data[nc]->read(addr, nullptr));
+      auto rdata = ic ? core_inst[nc]->read(addr, nullptr) : core_data[nc]->read(addr, nullptr);
       if(!tgen.check(addr, rdata)) return 1; // test failed!
     }
   }

--- a/regression/c2-l2-exc.cpp
+++ b/regression/c2-l2-exc.cpp
@@ -34,20 +34,5 @@ int main() {
   mem->attach_monitor(&tracer);
 
   RegressionGen<NCore, true, PAddrN, SAddrN, Data64B> tgen;
-
-  for(int i=0; i<TestN; i++) {
-    auto [addr, wdata, rw, nc, ic, flush] = tgen.gen();
-    if(flush) {
-      if(flush > 1) for( auto ci:core_inst) ci->flush(addr, nullptr); // shared instruction, flush all cores
-      else          core_inst[nc]->flush(addr, nullptr);
-      core_data[nc]->write(addr, wdata, nullptr);
-    } else if(rw) {
-      core_data[nc]->write(addr, wdata, nullptr);
-    } else {
-      auto rdata = ic ? core_inst[nc]->read(addr, nullptr) : core_data[nc]->read(addr, nullptr);
-      if(!tgen.check(addr, rdata)) return 1; // test failed!
-    }
-  }
-
-  return 0;
+  return tgen.run(TestN, core_inst, core_data);
 }

--- a/regression/c2-l2-exc.cpp
+++ b/regression/c2-l2-exc.cpp
@@ -1,8 +1,5 @@
-#include "cache/exclusive.hpp"
-#include "cache/index.hpp"
-#include "cache/replace.hpp"
 #include "cache/memory.hpp"
-#include "util/random.hpp"
+#include "util/cache_type.hpp"
 #include "util/regression.hpp"
 
 #define PAddrN 128
@@ -12,45 +9,17 @@
 
 #define L1IW 4
 #define L1WN 4
-#define L1Toff (L1IW + 6)
 
 #define L2IW 5
 #define L2WN 8
-#define L2Toff (L2IW + 6)
-
-typedef Data64B data_type;
-typedef MetadataMSIBroadcast<48, L1IW, L1Toff> l1_metadata_type;
-typedef IndexNorm<L1IW,6> l1_indexer_type;
-typedef ReplaceLRU<L1IW,L1WN,1> l1_replacer_type;
-typedef CacheNorm<L1IW,L1WN,l1_metadata_type,data_type,l1_indexer_type,l1_replacer_type,void,true> l1_type;
-typedef MSIPolicy<l1_metadata_type,true,false> l1_policy_type;
-typedef CoherentL1CacheNorm<l1_type, OuterCohPortUncached> l1i_cache_type;
-typedef CoherentL1CacheNorm<l1_type> l1d_cache_type;
-
-typedef MetadataMSIBroadcast<48, L2IW, L2Toff> l2_metadata_type;
-typedef IndexNorm<L2IW,6> l2_indexer_type;
-typedef ReplaceSRRIP<L2IW,L2WN,1> l2_replacer_type;
-typedef CacheNormExclusiveBroadcast<L2IW,L2WN,l2_metadata_type,data_type,l2_indexer_type,l2_replacer_type,void,true> l2_type;
-typedef ExclusiveMSIPolicy<l2_metadata_type,false,true> l2_policy_type;
-
-typedef OuterCohPortUncached memory_port_type;
-typedef ExclusiveLLCBroadcast<l2_type> l2_cache_type;
-typedef SimpleMemoryModel<data_type,void,true> memory_type;
 
 int main() {
-  auto l1_policy = new l1_policy_type();
-  std::vector<l1i_cache_type *> l1i(NCore);
-  std::vector<l1d_cache_type *> l1d(NCore);
-  std::vector<CoreInterface *>  core_inst(NCore), core_data(NCore);
-  for(int i=0; i<NCore; i++) {
-    l1i[i] = new l1i_cache_type(l1_policy, "l1i-" + std::to_string(i));
-    l1d[i] = new l1d_cache_type(l1_policy, "l1d-" + std::to_string(i));
-    core_inst[i] = static_cast<CoreInterface *>(l1i[i]->inner);
-    core_data[i] = static_cast<CoreInterface *>(l1d[i]->inner);
-  }
-  auto l2_policy = new l2_policy_type();
-  auto l2 = new l2_cache_type(l2_policy, "l2");
-  auto mem = new memory_type("mem");
+  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, false, void, true>(NCore, "l1d");
+  auto core_data = get_l1_core_interface(l1d);
+  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, true, void, true>(NCore, "l1i");
+  auto core_inst = get_l1_core_interface(l1i);
+  auto l2 = cache_gen_l2_exc<L2IW, L2WN, Data64B, MetadataBroadcastBase, ReplaceSRRIP, MSIPolicy, true, void, true>(1, "l2")[0];
+  auto mem = new SimpleMemoryModel<Data64B,void,true>("mem");
   SimpleTracer tracer(true);
 
   for(int i=0; i<NCore; i++) {
@@ -64,7 +33,7 @@ int main() {
   l2->attach_monitor(&tracer);
   mem->attach_monitor(&tracer);
 
-  RegressionGen<NCore, true, PAddrN, SAddrN, data_type> tgen;
+  RegressionGen<NCore, true, PAddrN, SAddrN, Data64B> tgen;
 
   for(int i=0; i<TestN; i++) {
     auto [addr, wdata, rw, nc, ic, flush] = tgen.gen();
@@ -75,9 +44,9 @@ int main() {
     } else if(rw) {
       core_data[nc]->write(addr, wdata, nullptr);
     } else {
-      const data_type *rdata;
-      if(ic) rdata = static_cast<const data_type *>(core_inst[nc]->read(addr, nullptr));
-      else   rdata = static_cast<const data_type *>(core_data[nc]->read(addr, nullptr));
+      const Data64B *rdata;
+      if(ic) rdata = static_cast<const Data64B *>(core_inst[nc]->read(addr, nullptr));
+      else   rdata = static_cast<const Data64B *>(core_data[nc]->read(addr, nullptr));
       if(!tgen.check(addr, rdata)) return 1; // test failed!
     }
   }

--- a/regression/c2-l2-mesi.cpp
+++ b/regression/c2-l2-mesi.cpp
@@ -44,9 +44,7 @@ int main() {
     } else if(rw) {
       core_data[nc]->write(addr, wdata, nullptr);
     } else {
-      const Data64B *rdata;
-      if(ic) rdata = static_cast<const Data64B *>(core_inst[nc]->read(addr, nullptr));
-      else   rdata = static_cast<const Data64B *>(core_data[nc]->read(addr, nullptr));
+      auto rdata = ic ? core_inst[nc]->read(addr, nullptr) : core_data[nc]->read(addr, nullptr);
       if(!tgen.check(addr, rdata)) return 1; // test failed!
     }
   }

--- a/regression/c2-l2-mesi.cpp
+++ b/regression/c2-l2-mesi.cpp
@@ -34,20 +34,5 @@ int main() {
   mem->attach_monitor(&tracer);
 
   RegressionGen<NCore, true, PAddrN, SAddrN, Data64B> tgen;
-
-  for(int i=0; i<TestN; i++) {
-    auto [addr, wdata, rw, nc, ic, flush] = tgen.gen();
-    if(flush) {
-      if(flush > 1) for( auto ci:core_inst) ci->flush(addr, nullptr); // shared instruction, flush all cores
-      else          core_inst[nc]->flush(addr, nullptr);
-      core_data[nc]->write(addr, wdata, nullptr);
-    } else if(rw) {
-      core_data[nc]->write(addr, wdata, nullptr);
-    } else {
-      auto rdata = ic ? core_inst[nc]->read(addr, nullptr) : core_data[nc]->read(addr, nullptr);
-      if(!tgen.check(addr, rdata)) return 1; // test failed!
-    }
-  }
-
-  return 0;
+  return tgen.run(TestN, core_inst, core_data);
 }

--- a/regression/c2-l2.cpp
+++ b/regression/c2-l2.cpp
@@ -1,10 +1,5 @@
-#include "cache/cache.hpp"
-#include "cache/index.hpp"
-#include "cache/replace.hpp"
-#include "cache/coherence.hpp"
-#include "cache/msi.hpp"
 #include "cache/memory.hpp"
-#include "util/random.hpp"
+#include "util/cache_type.hpp"
 #include "util/regression.hpp"
 
 #define PAddrN 128
@@ -14,45 +9,18 @@
 
 #define L1IW 4
 #define L1WN 4
-#define L1Toff (L1IW + 6)
 
 #define L2IW 5
 #define L2WN 8
 #define L2Toff (L2IW + 6)
 
-typedef Data64B data_type;
-typedef MetadataMSIBroadcast<48, L1IW, L1Toff> l1_metadata_type;
-typedef IndexNorm<L1IW,6> l1_indexer_type;
-typedef ReplaceLRU<L1IW,L1WN,true> l1_replacer_type;
-typedef CacheNorm<L1IW,L1WN,l1_metadata_type,data_type,l1_indexer_type,l1_replacer_type,void,true> l1_type;
-typedef MSIPolicy<l1_metadata_type,true,false> l1_policy_type;
-typedef CoherentL1CacheNorm<l1_type, OuterCohPortUncached> l1i_cache_type;
-typedef CoherentL1CacheNorm<l1_type> l1d_cache_type;
-
-typedef MetadataMSIBroadcast<48, L2IW, L2Toff> l2_metadata_type;
-typedef IndexNorm<L2IW,6> l2_indexer_type;
-typedef ReplaceSRRIP<L2IW,L2WN,true> l2_replacer_type;
-typedef CacheNorm<L2IW,L2WN,l2_metadata_type,data_type,l2_indexer_type,l2_replacer_type,void,true> l2_type;
-typedef MSIPolicy<l2_metadata_type,false,true> l2_policy_type;
-
-typedef OuterCohPortUncached memory_port_type;
-typedef CoherentCacheNorm<l2_type,memory_port_type> l2_cache_type;
-typedef SimpleMemoryModel<data_type,void,true> memory_type;
-
 int main() {
-  auto l1_policy = new l1_policy_type();
-  std::vector<l1i_cache_type *> l1i(NCore);
-  std::vector<l1d_cache_type *> l1d(NCore);
-  std::vector<CoreInterface *>  core_inst(NCore), core_data(NCore);
-  for(int i=0; i<NCore; i++) {
-    l1i[i] = new l1i_cache_type(l1_policy, "l1i-" + std::to_string(i));
-    l1d[i] = new l1d_cache_type(l1_policy, "l1d-" + std::to_string(i));
-    core_inst[i] = static_cast<CoreInterface *>(l1i[i]->inner);
-    core_data[i] = static_cast<CoreInterface *>(l1d[i]->inner);
-  }
-  auto l2_policy = new l2_policy_type();
-  auto l2 = new l2_cache_type(l2_policy, "l2");
-  auto mem = new memory_type("mem");
+  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, false, void, true>(NCore, "l1d");
+  auto core_data = get_l1_core_interface(l1d);
+  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, true, void, true>(NCore, "l1i");
+  auto core_inst = get_l1_core_interface(l1i);
+  auto l2 = cache_gen_l2_inc<L2IW, L2WN, Data64B, MetadataBroadcastBase, ReplaceSRRIP, MSIPolicy, true, void, true>(1, "l2")[0];
+  auto mem = new SimpleMemoryModel<Data64B,void,true>("mem");
   SimpleTracer tracer(true);
 
   for(int i=0; i<NCore; i++) {
@@ -66,7 +34,7 @@ int main() {
   l2->attach_monitor(&tracer);
   mem->attach_monitor(&tracer);
 
-  RegressionGen<NCore, true, PAddrN, SAddrN, data_type> tgen;
+  RegressionGen<NCore, true, PAddrN, SAddrN, Data64B> tgen;
 
   for(int i=0; i<TestN; i++) {
     auto [addr, wdata, rw, nc, ic, flush] = tgen.gen();
@@ -77,9 +45,9 @@ int main() {
     } else if(rw) {
       core_data[nc]->write(addr, wdata, nullptr);
     } else {
-      const data_type *rdata;
-      if(ic) rdata = static_cast<const data_type *>(core_inst[nc]->read(addr, nullptr));
-      else   rdata = static_cast<const data_type *>(core_data[nc]->read(addr, nullptr));
+      const Data64B *rdata;
+      if(ic) rdata = static_cast<const Data64B *>(core_inst[nc]->read(addr, nullptr));
+      else   rdata = static_cast<const Data64B *>(core_data[nc]->read(addr, nullptr));
       if(!tgen.check(addr, rdata)) return 1; // test failed!
     }
   }

--- a/regression/c2-l2.cpp
+++ b/regression/c2-l2.cpp
@@ -45,9 +45,7 @@ int main() {
     } else if(rw) {
       core_data[nc]->write(addr, wdata, nullptr);
     } else {
-      const Data64B *rdata;
-      if(ic) rdata = static_cast<const Data64B *>(core_inst[nc]->read(addr, nullptr));
-      else   rdata = static_cast<const Data64B *>(core_data[nc]->read(addr, nullptr));
+      auto rdata = ic ? core_inst[nc]->read(addr, nullptr) : core_data[nc]->read(addr, nullptr);
       if(!tgen.check(addr, rdata)) return 1; // test failed!
     }
   }

--- a/util/cache_type.hpp
+++ b/util/cache_type.hpp
@@ -1,0 +1,126 @@
+#ifndef CM_UTIL_CACHE_TYPE_HPP
+#define CM_UTIL_CACHE_TYPE_HPP
+
+// a header for ease the construction of cache types
+
+#include "cache/exclusive.hpp"
+#include "cache/mesi.hpp"
+#include "cache/index.hpp"
+#include "cache/replace.hpp"
+
+#include <vector>
+
+template<typename CT, typename CPT>
+inline std::vector<CoherentCacheBase *> cache_generator(int size, const std::string& name_prefix) {
+  auto policy = new CPT();
+  auto array = std::vector<CoherentCacheBase *>(size);
+  for(int i=0; i<size; i++) array[i] = new CT(policy, name_prefix + (size > 1 ? "-"+std::to_string(i) : ""));
+  return array;
+}
+
+inline auto get_l1_core_interface(std::vector<CoherentCacheBase *>& array) {
+  auto core = std::vector<CoreInterface *>(array.size());
+  for(int i=0; i<array.size(); i++)
+    core[i] = static_cast<CoreInterface *>(array[i]->inner);
+  return core;
+}
+
+template<int IW, int WN, int DW, typename DT, typename MBT,
+         template <int, int, bool> class RPT,
+         template <int, int, bool> class DRPT,
+         template <typename, bool, bool> class CPT,
+         bool isL1, bool isLLC, bool uncache, bool isExc, typename DLY, bool EnMon>
+inline auto cache_type_compile(int size, const std::string& name_prefix) {
+  typedef IndexNorm<IW,6> index_type;
+  typedef RPT<IW,WN,true> replace_type;
+  typedef DRPT<IW,DW,true> ext_replace_type;
+
+  constexpr bool isDir  = std::is_same_v<MBT, MetadataDirectoryBase>;
+  constexpr bool isMESI = std::is_same_v<CPT<MetadataDirectoryBase, false, true>, MESIPolicy<MetadataDirectoryBase, false, true> >;
+  constexpr bool isMSI  = std::is_same_v<CPT<MetadataDirectoryBase, false, true>, MSIPolicy<MetadataDirectoryBase, false, true> >;
+  constexpr bool isMI   = std::is_same_v<CPT<MetadataDirectoryBase, false, true>, MIPolicy<MetadataDirectoryBase, false, true> >;
+
+  // ports
+  typedef typename std::conditional<isL1, CoreInterface,
+                                    typename std::conditional<isExc,
+                                      typename std::conditional<isDir, ExclusiveInnerCohPortDirectory, ExclusiveInnerCohPortBroadcast>::type,
+                                      InnerCohPort>::type >::type input_type;
+  typedef typename std::conditional<isLLC || uncache, OuterCohPortUncached,
+                                    typename std::conditional<isExc,
+                                      typename std::conditional<isDir, ExclusiveOuterCohPortDirectory, ExclusiveOuterCohPortBroadcast>::type,
+                                      OuterCohPort>::type >::type output_type;
+
+  // MESI
+  typedef MetadataMESIDirectory<48, IW, IW+6> mesi_metadata_type;
+  typedef typename std::conditional<isExc,
+                                    ExclusiveMESIPolicy<mesi_metadata_type, true, isLLC>,
+                                    MESIPolicy<mesi_metadata_type, false, isLLC>
+                                    >::type mesi_policy_type;
+  if constexpr (isMESI && isExc) assert(isDir);
+
+  // MSI
+  typedef typename std::conditional<isDir, MetadataMSIDirectory<48, IW, IW+6>, MetadataMSIBroadcast<48, IW, IW+6> >::type msi_metadata_type;
+  typedef typename std::conditional<isExc,
+                                    ExclusiveMSIPolicy<msi_metadata_type, isDir, isLLC>,
+                                    MSIPolicy<msi_metadata_type, false, isLLC>
+                                    >::type msi_policy_type;
+
+  // MI
+  typedef MetadataMIBroadcast<48, IW, IW+6> mi_metadata_type;
+  typedef MIPolicy<mi_metadata_type, true, isLLC> mi_policy_type;
+  if constexpr (isMI) assert(!isDir && !isExc);
+
+  typedef typename std::conditional<isMESI, mesi_metadata_type,
+          typename std::conditional<isMSI,  msi_metadata_type,
+                                            mi_metadata_type>::type >::type metadata_type;
+
+  typedef typename std::conditional<isMESI, mesi_policy_type,
+          typename std::conditional<isMSI,  msi_policy_type,
+                                            mi_policy_type>::type >::type policy_type;
+
+  typedef typename std::conditional<
+    isExc, typename std::conditional<
+             isDir, CacheNormExclusiveDirectory<IW, WN, DW, metadata_type, DT, index_type, replace_type, ext_replace_type, DLY, EnMon>,
+                    CacheNormExclusiveBroadcast<IW, WN,     metadata_type, DT, index_type, replace_type,                   DLY, EnMon> >::type,
+           CacheNorm<IW, WN, metadata_type, DT, index_type, replace_type, DLY, EnMon> >::type cache_base_type;
+
+  typedef CoherentCacheNorm<cache_base_type, output_type, input_type> cache_type;
+  return cache_generator<cache_type, policy_type>(size, name_prefix);
+}
+
+template<int IW, int WN, typename DT, typename MBT,
+         template <int, int, bool> class RPT,
+         template <typename, bool, bool> class CPT,
+         bool isLLC, bool uncache, typename DLY, bool EnMon>
+inline auto cache_gen_l1(int size, const std::string& name_prefix) {
+  return cache_type_compile<IW, WN, 1, DT, MBT, RPT, ReplaceLRU, CPT, true, isLLC, uncache, false, DLY, EnMon>(size, name_prefix);
+}
+
+template<int IW, int WN, typename DT, typename MBT,
+         template <int, int, bool> class RPT,
+         template <typename, bool, bool> class CPT,
+         bool isLLC, typename DLY, bool EnMon>
+inline auto cache_gen_l2_inc(int size, const std::string& name_prefix) {
+  return cache_type_compile<IW, WN, 1, DT, MBT, RPT, ReplaceLRU, CPT, false, isLLC, false, false, DLY, EnMon>(size, name_prefix);
+}
+
+template<int IW, int WN, typename DT, typename MBT,
+         template <int, int, bool> class RPT,
+         template <typename, bool, bool> class CPT,
+         bool isLLC, typename DLY, bool EnMon>
+inline auto cache_gen_l2_exc(int size, const std::string& name_prefix) {
+  return cache_type_compile<IW, WN, 1,  DT, MBT, RPT, ReplaceLRU, CPT, false, isLLC, false, true, DLY, EnMon>(size, name_prefix);
+}
+
+template<int IW, int WN, int DW, typename DT, typename MBT,
+         template <int, int, bool> class RPT,
+         template <int, int, bool> class DRPT,
+         template <typename, bool, bool> class CPT,
+         bool isLLC, typename DLY, bool EnMon>
+inline auto cache_gen_l2_exc(int size, const std::string& name_prefix) {
+  constexpr bool isDir  = std::is_same_v<MBT, MetadataDirectoryBase>;
+  assert(isDir);
+  return cache_type_compile<IW, WN, DW, DT, MBT, RPT, DRPT,       CPT, false, isLLC, false, true, DLY, EnMon>(size, name_prefix);
+}
+
+#endif

--- a/util/regression.hpp
+++ b/util/regression.hpp
@@ -86,7 +86,7 @@ public:
     return std::make_tuple(addr, data, rw, core, ic, flush);
   }
 
-  bool check(uint64_t addr, const DT *data) {
+  bool check(uint64_t addr, const CMDataBase *data) {
     assert(addr_map.count(addr));
     int index = addr_map[addr];
     assert(data_pool[index].read(0) == data->read(0));


### PR DESCRIPTION
* add a `cache_type.hpp` helper to ease the way of defining and implementing caches.
* Simplify regression testing.