### PR TITLE
delay the filling of (set,way) in query

### DIFF
--- a/cache/cache.hpp
+++ b/cache/cache.hpp
@@ -140,7 +140,8 @@ public:
   virtual std::pair<CMMetadataBase *, CMDataBase *> access_line(uint32_t ai, uint32_t s, uint32_t w) = 0;
 
   virtual bool query_coloc(uint64_t addrA, uint64_t addrB) = 0;
-  virtual LocInfo query_loc(uint64_t addr) = 0;
+  virtual LocInfo query_loc(uint64_t addr) { return LocInfo(id, this, addr); }
+  virtual void query_fill_loc(LocInfo *loc, uint64_t addr) = 0;
 };
 
 // Skewed Cache
@@ -275,12 +276,10 @@ public:
     return false;
   }
 
-  virtual LocInfo query_loc(uint64_t addr) {
-    LocInfo rv(id, this);
+  virtual void query_fill_loc(LocInfo *loc, uint64_t addr) {
     for(int i=0; i<P; i++){
-      rv.insert(LocIdx(i, indexer.index(addr, i)), LocRange(0, NW-1));
+      loc->insert(LocIdx(i, indexer.index(addr, i)), LocRange(0, NW-1));
     }
-    return rv;
   }
 };
 

--- a/util/query.cpp
+++ b/util/query.cpp
@@ -1,5 +1,6 @@
 #include "util/query.hpp"
 #include "cache/cache.hpp"
+#include <boost/format.hpp>
 
 std::string LocIdx::to_string() const{
   auto fmt = boost::format("partition: %1%, idx: %2%, way: ") % ai % idx;
@@ -26,4 +27,12 @@ std::string LocInfo::to_string() const{
     else { rv += "."; break; }
   }
   return rv;
+}
+
+void LocInfo::fill() {
+  cache->query_fill_loc(this, addr);
+}
+
+bool LocInfo::hit() {
+  return cache->hit(addr);
 }

--- a/util/query.hpp
+++ b/util/query.hpp
@@ -1,10 +1,9 @@
 #ifndef UTIL_QUERY_HPP_
 #define UTIL_QUERY_HPP_
 
-#include <unordered_set>
+#include <unordered_map>
 #include <utility>
 #include <string>
-#include <boost/format.hpp>
 
 class CacheBase;
 
@@ -42,14 +41,17 @@ public:
 
 // the possible location of an address in a cache
 class LocInfo {
+  bool filled;
+  uint64_t addr;
 public:
   uint32_t cache_id;
   CacheBase* cache;
-//   CoherentCacheBase* wrapper;
   std::unordered_map<LocIdx, LocRange> locs;
   LocInfo() : cache_id(0) {}
-  LocInfo(uint32_t cache_id, CacheBase* cache) : cache_id(cache_id), cache(cache) {}
+  LocInfo(uint32_t cache_id, CacheBase* cache, uint64_t addr) : filled(false), addr(addr), cache_id(cache_id), cache(cache) {}
   void insert(LocIdx idx, LocRange r) { locs[idx] = r; }
+  void fill();
+  bool hit();
   std::string to_string() const;
 };
 #endif


### PR DESCRIPTION
The current cache query is unnecessarily heavy.
I think there is no need to fill the initial location list during the query.
Most of the query would be used to check whether an address hits in a certain level of cache, rather than investigating the potential partition, set or way. If this is really the purpose, this information can be filled later.
So comes the PR, to delay the filling with a later callable fill method.

@SkyAlbatross @HanJinChi @wangzd12138

If there is no objection, I will merge this next week.