### PR TITLE
allow allocating local randomizer

### DIFF
--- a/util/random.cpp
+++ b/util/random.cpp
@@ -1,27 +1,55 @@
 #include "util/random.hpp"
 #include <random>
+#include <type_traits>
 
 // local variables (file local linkage)
 namespace {
 
-  std::random_device rd;
-  std::uniform_int_distribution<uint32_t> uniform32(0, 1ul<<31);
-  std::uniform_int_distribution<uint64_t> uniform64(0, 1ull<<63);
+  template<typename rv_type, typename rand_gen_type, uint64_t max_value>
+  class RandomGenBase : public RandomGen<rv_type> {
+    rand_gen_type rand_gen;
+    std::uniform_int_distribution<rv_type> uniform;
+  public:
+    RandomGenBase() : uniform(0, max_value) {}
+    RandomGenBase(unsigned int s) : rand_gen(s), uniform(0, max_value) {}
+    virtual rv_type operator ()() {return uniform(rand_gen); }
+    virtual void seed(uint64_t s) {rand_gen.seed(s); }
+  };
 
+  template<typename rv_type, uint64_t max_value>
+  using RandomGenDeault = RandomGenBase<rv_type, std::default_random_engine, max_value>;
+
+  template<typename rv_type, uint64_t max_value>
+  using RandomGenMT = RandomGenBase<rv_type,
+                                    typename std::conditional<std::is_same<rv_type, uint64_t>::value, std::mt19937_64, std::mt19937>::type,
+                                    max_value>;
   // random engine
+  std::random_device rd;
 #ifdef NDEBUG
   // release mode
   // seed the mt19937 engine (normally better than default) with actual hardware generated random numbers
-  std::mt19937    gen32(rd());
-  std::mt19937_64 gen64(rd());
+  RandomGenMT<uint32_t, (1ull<<31)> g_gen32(rd());
+  RandomGenMT<uint64_t, (1ull<<63)> g_gen64(rd());
 #else
-  std::default_random_engine gen32, gen64;
+  RandomGenDeault<uint32_t, (1ull<<31)> g_gen32;
+  RandomGenDeault<uint64_t, (1ull<<63)> g_gen64;
 #endif
+
 }
 
 unsigned int cm_get_true_random() { return rd(); }
-void cm_set_random_seed(uint64_t seed) { gen32.seed(seed); gen64.seed(seed); }
-uint64_t cm_get_random_uint64() { return uniform64(gen64); }
-uint32_t cm_get_random_uint32() { return uniform32(gen32); }
+void cm_set_random_seed(uint64_t seed) { g_gen32.seed(seed); g_gen64.seed(seed); }
+uint64_t cm_get_random_uint64() { return g_gen64(); }
+uint32_t cm_get_random_uint32() { return g_gen32(); }
+
+// allocate localized random number generator, normally for the multi-thread use case
+#ifdef NDEBUG
+  // release mode
+  RandomGen<uint32_t> *alloc_rand32() { return new RandomGenMT<uint32_t, (1ull<<31)>(rd()); }
+  RandomGen<uint64_t> *alloc_rand64() { return new RandomGenMT<uint64_t, (1ull<<63)>(rd()); }
+#else
+  RandomGen<uint32_t> *alloc_rand32() { return new RandomGenDeault<uint32_t, (1ull<<31)>(); }
+  RandomGen<uint64_t> *alloc_rand64() { return new RandomGenDeault<uint64_t, (1ull<<63)>(); }
+#endif
 
 std::unordered_map<uint32_t, std::string> UniqueID::ids;

--- a/util/random.hpp
+++ b/util/random.hpp
@@ -5,10 +5,19 @@
 #include <unordered_map>
 #include <string>
 
+template<typename rv_type>
+class RandomGen {
+public:
+  virtual rv_type operator ()() = 0;
+  virtual void seed(uint64_t s) = 0;
+};
+
 extern unsigned int cm_get_true_random();
 extern void cm_set_random_seed(uint64_t seed);
 extern uint64_t cm_get_random_uint64();
 extern uint32_t cm_get_random_uint32();
+extern RandomGen<uint32_t> *alloc_rand32(); // generate a local random generator for a thread
+extern RandomGen<uint64_t> *alloc_rand64();
 
 #include "cryptopp/cryptlib.h"
 #include "cryptopp/tiger.h"


### PR DESCRIPTION
In the multithread test, the globally shared randomizer seems to be a speed killer. This PR would allow threads have localized randomizers.