### PR TITLE
Fix some memory leakage issues

### DIFF
--- a/cache/coherence.hpp
+++ b/cache/coherence.hpp
@@ -5,6 +5,7 @@
 #include "cache/coh_policy.hpp"
 #include "cache/slicehash.hpp"
 #include <tuple>
+#include <memory>
 
 class OuterCohPortBase;
 class InnerCohPortBase;
@@ -16,6 +17,8 @@ class CoherentCacheBase;
 typedef OuterCohPortBase CohClientBase;
 typedef InnerCohPortBase CohMasterBase;
 
+typedef std::shared_ptr<CohPolicyBase> policy_ptr;
+
 /////////////////////////////////
 // Base interface for outer ports
 
@@ -26,13 +29,13 @@ protected:
   InnerCohPortBase *inner; // inner port for probe when sync
   CohMasterBase *coh;      // hook up with the coherence hub
   int32_t coh_id;          // the identifier used in locating this cache client by the coherence master
-  CohPolicyBase *policy;   // the coherence policy
+  policy_ptr policy;       // the coherence policy
 
 public:
-  OuterCohPortBase(CohPolicyBase *policy) : policy(policy) {}
+  OuterCohPortBase(policy_ptr policy) : policy(policy) {}
   virtual ~OuterCohPortBase() {}
 
-  void connect(CohMasterBase *h, std::pair<int32_t, CohPolicyBase *> info) { coh = h; coh_id = info.first; policy->connect(info.second); }
+  void connect(CohMasterBase *h, std::pair<int32_t, policy_ptr> info) { coh = h; coh_id = info.first; policy->connect(info.second.get()); }
 
   virtual void acquire_req(uint64_t addr, CMMetadataBase *meta, CMDataBase *data, coh_cmd_t cmd, uint64_t *delay) = 0;
   virtual void writeback_req(uint64_t addr, CMMetadataBase *meta, CMDataBase *data, coh_cmd_t cmd, uint64_t *delay) = 0;
@@ -52,12 +55,11 @@ protected:
   CacheBase *cache; // reverse pointer for the cache parent
   OuterCohPortBase *outer; // outer port for writeback when replace
   std::vector<CohClientBase *> coh; // hook up with the inner caches, indexed by vector index
-  CohPolicyBase *policy; // the coherence policy
+  policy_ptr policy; // the coherence policy
 public:
-  InnerCohPortBase(CohPolicyBase *policy) : policy(policy) {}
-  virtual ~InnerCohPortBase() { delete policy; }
+  InnerCohPortBase(policy_ptr policy) : policy(policy) {}
 
-  std::pair<uint32_t, CohPolicyBase *> connect(CohClientBase *c, bool uncached = false) {
+  std::pair<uint32_t, policy_ptr> connect(CohClientBase *c, bool uncached = false) {
     if(uncached) {
       return std::make_pair(-1, policy);
     } else {
@@ -79,7 +81,7 @@ public:
 class OuterCohPortUncached : public OuterCohPortBase
 {
 public:
-  OuterCohPortUncached(CohPolicyBase *policy) : OuterCohPortBase(policy) {}
+  OuterCohPortUncached(policy_ptr policy) : OuterCohPortBase(policy) {}
   virtual ~OuterCohPortUncached() {}
 
   virtual void acquire_req(uint64_t addr, CMMetadataBase *meta, CMDataBase *data, coh_cmd_t outer_cmd, uint64_t *delay) {
@@ -110,7 +112,7 @@ protected:
   using OuterCohPortBase::inner;
   using OPUC::writeback_req;
 public:
-  OuterCohPortT(CohPolicyBase *policy) : OPUC(policy) {}
+  OuterCohPortT(policy_ptr policy) : OPUC(policy) {}
   virtual ~OuterCohPortT() {}
 
   virtual std::pair<bool,bool> probe_resp(uint64_t addr, CMMetadataBase *meta_outer, CMDataBase *data_outer, coh_cmd_t outer_cmd, uint64_t *delay) {
@@ -145,7 +147,7 @@ typedef OuterCohPortT<OuterCohPortUncached> OuterCohPort;
 class InnerCohPortUncached : public InnerCohPortBase
 {
 public:
-  InnerCohPortUncached(CohPolicyBase *policy) : InnerCohPortBase(policy) {}
+  InnerCohPortUncached(policy_ptr policy) : InnerCohPortBase(policy) {}
   virtual ~InnerCohPortUncached() {}
 
   virtual void acquire_resp(uint64_t addr, CMDataBase *data_inner, CMMetadataBase *meta_inner, coh_cmd_t cmd, uint64_t *delay) {
@@ -263,7 +265,7 @@ class InnerCohPortT : public IPUC
 protected:
   using IPUC::coh;
 public:
-  InnerCohPortT(CohPolicyBase *policy) : IPUC(policy) {}
+  InnerCohPortT(policy_ptr policy) : IPUC(policy) {}
   virtual ~InnerCohPortT() {}
 
   virtual std::pair<bool, bool> probe_req(uint64_t addr, CMMetadataBase *meta, CMDataBase *data, coh_cmd_t cmd, uint64_t *delay) {
@@ -285,7 +287,7 @@ typedef InnerCohPortT<InnerCohPortUncached> InnerCohPort;
 // interface with the processing core is a special InnerCohPort
 class CoreInterface : public InnerCohPortUncached {
 public:
-  CoreInterface(CohPolicyBase *policy) : InnerCohPortUncached(policy) {}
+  CoreInterface(policy_ptr policy) : InnerCohPortUncached(policy) {}
   virtual ~CoreInterface() {}
 
   uint64_t normalize(uint64_t addr) const { return addr & ~0x3full; }
@@ -357,7 +359,7 @@ public:
   OuterCohPortBase *outer; // coherence outer port, nullptr if last level
   InnerCohPortBase *inner; // coherence inner port, always has inner
 
-  CoherentCacheBase(CacheBase *cache, OuterCohPortBase *outer, InnerCohPortBase *inner, CohPolicyBase *policy, std::string name)
+  CoherentCacheBase(CacheBase *cache, OuterCohPortBase *outer, InnerCohPortBase *inner, policy_ptr policy, std::string name)
     : name(name), cache(cache), outer(outer), inner(inner)
   {
     // deferred assignment for the reverse pointer to cache
@@ -385,7 +387,7 @@ template<typename CacheT, typename OuterT = OuterCohPort, typename InnerT = Inne
 class CoherentCacheNorm : public CoherentCacheBase
 {
 public:
-  CoherentCacheNorm(CohPolicyBase *policy, std::string name = "") : CoherentCacheBase(new CacheT(name), new OuterT(policy), new InnerT(policy), policy, name) {}
+  CoherentCacheNorm(policy_ptr policy, std::string name = "") : CoherentCacheBase(new CacheT(name), new OuterT(policy), new InnerT(policy), policy, name) {}
   virtual ~CoherentCacheNorm() {}
 };
 

--- a/cache/exclusive.hpp
+++ b/cache/exclusive.hpp
@@ -193,7 +193,7 @@ class ExclusiveInnerCohPortUncachedBroadcast : public InnerCohPortUncached
 protected:
   using InnerCohPortBase::cache;
 public:
-  ExclusiveInnerCohPortUncachedBroadcast(CohPolicyBase *policy) : InnerCohPortUncached(policy) {}
+  ExclusiveInnerCohPortUncachedBroadcast(policy_ptr policy) : InnerCohPortUncached(policy) {}
   virtual ~ExclusiveInnerCohPortUncachedBroadcast() {}
 
   virtual void acquire_resp(uint64_t addr, CMDataBase *data_inner, CMMetadataBase *meta_inner, coh_cmd_t cmd, uint64_t *delay) {
@@ -355,7 +355,7 @@ class ExclusiveInnerCohPortUncachedDirectory : public InnerCohPortUncached
 protected:
   using InnerCohPortBase::cache;
 public:
-  ExclusiveInnerCohPortUncachedDirectory(CohPolicyBase *policy) : InnerCohPortUncached(policy) {}
+  ExclusiveInnerCohPortUncachedDirectory(policy_ptr policy) : InnerCohPortUncached(policy) {}
   virtual ~ExclusiveInnerCohPortUncachedDirectory() {}
 
   virtual void acquire_resp(uint64_t addr, CMDataBase *data_inner, CMMetadataBase *meta_inner, coh_cmd_t outer_cmd, uint64_t *delay) {
@@ -526,7 +526,7 @@ protected:
   using OPUC::inner;
   using OPUC::policy;
 public:
-  ExclusiveOuterCohPortBroadcastT(CohPolicyBase *policy) : OPUC(policy) {}
+  ExclusiveOuterCohPortBroadcastT(policy_ptr policy) : OPUC(policy) {}
   virtual ~ExclusiveOuterCohPortBroadcastT() {}
 
   virtual std::pair<bool, bool> probe_resp(uint64_t addr, CMMetadataBase *meta_outer, CMDataBase *data_outer, coh_cmd_t outer_cmd, uint64_t *delay) {
@@ -577,7 +577,7 @@ protected:
   using OPUC::inner;
   using OPUC::policy;
 public:
-  ExclusiveOuterCohPortDirectoryT(CohPolicyBase *policy) : OPUC(policy) {}
+  ExclusiveOuterCohPortDirectoryT(policy_ptr policy) : OPUC(policy) {}
   virtual ~ExclusiveOuterCohPortDirectoryT() {}
 
   virtual std::pair<bool, bool> probe_resp(uint64_t addr, CMMetadataBase *meta_outer, CMDataBase *data_outer, coh_cmd_t outer_cmd, uint64_t *delay) {

--- a/cache/exclusive.hpp
+++ b/cache/exclusive.hpp
@@ -7,7 +7,6 @@
 template<typename MT, bool EnDir, bool isLLC> requires C_DERIVE(MT, CMMetadataBase)
 class ExclusiveMSIPolicy : public MSIPolicy<MT, false, isLLC>    // always not L1
 {
-  typedef MSIPolicy<MT, false, isLLC> PolicyT;
 protected:
   using CohPolicyBase::is_fetch_read;
   using CohPolicyBase::is_fetch_write;
@@ -83,7 +82,6 @@ public:
 template<typename MT, bool EnDir, bool isLLC> requires C_DERIVE(MT, MetadataDirectoryBase) && EnDir
 class ExclusiveMESIPolicy : public ExclusiveMSIPolicy<MT, true, isLLC>
 {
-  typedef ExclusiveMSIPolicy<MT, true, isLLC> PolicyT;
 protected:
   using CohPolicyBase::is_fetch_read;
   using CohPolicyBase::is_fetch_write;

--- a/cache/memory.hpp
+++ b/cache/memory.hpp
@@ -26,13 +26,12 @@ public:
   SimpleMemoryModel(const std::string &n)
     : InnerCohPortUncached(nullptr), id(UniqueID::new_id(n)), name(n)
   {
-    InnerCohPortBase::policy = new MIPolicy<MetadataMI,false,false>();
+    InnerCohPortBase::policy = policy_ptr(new MIPolicy<MetadataMI,false,false>());
     CacheMonitorSupport::monitors = new CacheMonitorImp<DLY, EnMon>(id);
   }
 
   virtual ~SimpleMemoryModel() {
     delete CacheMonitorSupport::monitors;
-    delete InnerCohPortBase::policy;
   }
 
   virtual void acquire_resp(uint64_t addr, CMDataBase *data_inner, CMMetadataBase *meta_inner, coh_cmd_t cmd, uint64_t *delay) {

--- a/cache/mirage.hpp
+++ b/cache/mirage.hpp
@@ -237,7 +237,7 @@ template<typename MT, typename CT>
 class MirageInnerPortUncached : public InnerCohPortUncached
 {
 public:
-  MirageInnerPortUncached(CohPolicyBase *policy) : InnerCohPortUncached(policy) {}
+  MirageInnerPortUncached(policy_ptr policy) : InnerCohPortUncached(policy) {}
 protected:
   virtual std::tuple<CMMetadataBase *, CMDataBase *, uint32_t, uint32_t, uint32_t>
   replace_line(uint64_t addr, uint64_t *delay) {

--- a/cache/mirage.hpp
+++ b/cache/mirage.hpp
@@ -70,8 +70,6 @@ template<typename MT, typename CT>
 class MirageMSIPolicy : public MSIPolicy<MT, false, true> // always LLC, always not L1
 {
   typedef MSIPolicy<MT, false, true> PolicyT;
-protected:
-  using PolicyT::outer;
 public:
   MirageMSIPolicy() : MSIPolicy<MT, false, true>() {}
   virtual ~MirageMSIPolicy() {}

--- a/regression/c1-l1.cpp
+++ b/regression/c1-l1.cpp
@@ -17,5 +17,9 @@ int main() {
   mem->attach_monitor(&tracer);
 
   RegressionGen<1, false, false, AddrN, 0, Data64B> tgen;
-  return tgen.run(TestN, core, core);
+  auto rv = tgen.run(TestN, core, core);
+
+  delete_caches(cache);
+  delete mem;
+  return rv;
 }

--- a/regression/c2-l2-exc-mesi.cpp
+++ b/regression/c2-l2-exc-mesi.cpp
@@ -35,5 +35,11 @@ int main() {
   mem->attach_monitor(&tracer);
 
   RegressionGen<NCore, true, false, PAddrN, SAddrN, Data64B> tgen;
-  return tgen.run(TestN, core_inst, core_data);
+  auto rv = tgen.run(TestN, core_inst, core_data);
+
+  delete_caches(l1d);
+  delete_caches(l1i);
+  delete l2;
+  delete mem;
+  return rv;
 }

--- a/regression/c2-l2-exc-mi.cpp
+++ b/regression/c2-l2-exc-mi.cpp
@@ -34,5 +34,11 @@ int main() {
   mem->attach_monitor(&tracer);
 
   RegressionGen<NCore, true, false, PAddrN, SAddrN, Data64B> tgen;
-  return tgen.run(TestN, core_inst, core_data);
+  auto rv = tgen.run(TestN, core_inst, core_data);
+
+  delete_caches(l1d);
+  delete_caches(l1i);
+  delete l2;
+  delete mem;
+  return rv;
 }

--- a/regression/c2-l2-exc.cpp
+++ b/regression/c2-l2-exc.cpp
@@ -34,5 +34,11 @@ int main() {
   mem->attach_monitor(&tracer);
 
   RegressionGen<NCore, true, false, PAddrN, SAddrN, Data64B> tgen;
-  return tgen.run(TestN, core_inst, core_data);
+  auto rv = tgen.run(TestN, core_inst, core_data);
+
+  delete_caches(l1d);
+  delete_caches(l1i);
+  delete l2;
+  delete mem;
+  return rv;
 }

--- a/regression/c2-l2-mesi.cpp
+++ b/regression/c2-l2-mesi.cpp
@@ -34,5 +34,11 @@ int main() {
   mem->attach_monitor(&tracer);
 
   RegressionGen<NCore, true, false, PAddrN, SAddrN, Data64B> tgen;
-  return tgen.run(TestN, core_inst, core_data);
+  auto rv = tgen.run(TestN, core_inst, core_data);
+
+  delete_caches(l1d);
+  delete_caches(l1i);
+  delete l2;
+  delete mem;
+  return rv;
 }

--- a/regression/c2-l2-mirage.cpp
+++ b/regression/c2-l2-mirage.cpp
@@ -37,5 +37,11 @@ int main() {
   mem->attach_monitor(&tracer);
 
   RegressionGen<NCore, true, false, PAddrN, SAddrN, Data64B> tgen;
-  return tgen.run(TestN, core_inst, core_data);
+  auto rv = tgen.run(TestN, core_inst, core_data);
+
+  delete_caches(l1d);
+  delete_caches(l1i);
+  delete l2;
+  delete mem;
+  return rv;
 }

--- a/regression/c2-l2.cpp
+++ b/regression/c2-l2.cpp
@@ -34,5 +34,11 @@ int main() {
   mem->attach_monitor(&tracer);
 
   RegressionGen<NCore, true, false, PAddrN, SAddrN, Data64B> tgen;
-  return tgen.run(TestN, core_inst, core_data);
+  auto rv = tgen.run(TestN, core_inst, core_data);
+
+  delete_caches(l1d);
+  delete_caches(l1i);
+  delete l2;
+  delete mem;
+  return rv;
 }

--- a/regression/c4-l3-exc-mesi.cpp
+++ b/regression/c4-l3-exc-mesi.cpp
@@ -41,5 +41,12 @@ int main() {
   mem->attach_monitor(&tracer);
 
   RegressionGen<NCore, true, true, PAddrN, SAddrN, Data64B> tgen;
-  return tgen.run(TestN, core_inst, core_data);
+  auto rv = tgen.run(TestN, core_inst, core_data);
+
+  delete_caches(l1d);
+  delete_caches(l1i);
+  delete_caches(l2);
+  delete l3;
+  delete mem;
+  return rv;
 }

--- a/regression/c4-l3-exc.cpp
+++ b/regression/c4-l3-exc.cpp
@@ -40,5 +40,12 @@ int main() {
   mem->attach_monitor(&tracer);
 
   RegressionGen<NCore, true, false, PAddrN, SAddrN, Data64B> tgen;
-  return tgen.run(TestN, core_inst, core_data);
+  auto rv = tgen.run(TestN, core_inst, core_data);
+
+  delete_caches(l1d);
+  delete_caches(l1i);
+  delete_caches(l2);
+  delete l3;
+  delete mem;
+  return rv;
 }

--- a/regression/c4-l3-intel.cpp
+++ b/regression/c4-l3-intel.cpp
@@ -43,5 +43,12 @@ int main() {
   mem->attach_monitor(&tracer);
 
   RegressionGen<NCore, true, true, PAddrN, SAddrN, Data64B> tgen;
-  return tgen.run(TestN, core_inst, core_data);
+  auto rv = tgen.run(TestN, core_inst, core_data);
+
+  delete_caches(l1d);
+  delete_caches(l1i);
+  delete_caches(l2);
+  delete_caches(l3);
+  delete mem;
+  return rv;
 }

--- a/regression/c4-l3.cpp
+++ b/regression/c4-l3.cpp
@@ -40,5 +40,12 @@ int main() {
   mem->attach_monitor(&tracer);
 
   RegressionGen<NCore, true, false, PAddrN, SAddrN, Data64B> tgen;
-  return tgen.run(TestN, core_inst, core_data);
+  auto rv = tgen.run(TestN, core_inst, core_data);
+
+  delete_caches(l1d);
+  delete_caches(l1i);
+  delete_caches(l2);
+  delete l3;
+  delete mem;
+  return rv;
 }

--- a/util/cache_type.hpp
+++ b/util/cache_type.hpp
@@ -13,7 +13,7 @@
 
 template<typename CT, typename CPT>
 inline std::vector<CoherentCacheBase *> cache_generator(int size, const std::string& name_prefix) {
-  auto policy = new CPT();
+  policy_ptr policy(new CPT());
   auto array = std::vector<CoherentCacheBase *>(size);
   for(int i=0; i<size; i++) array[i] = new CT(policy, name_prefix + (size > 1 ? "-"+std::to_string(i) : ""));
   return array;

--- a/util/regression.hpp
+++ b/util/regression.hpp
@@ -121,4 +121,8 @@ public:
   }
 };
 
+inline void delete_caches(std::vector<CoherentCacheBase *> &caches) {
+  for(auto c : caches) delete c;
+}
+
 #endif


### PR DESCRIPTION
* Explicitly delete caches at the end of each regression test.
* As policy might be shared by multiple caches, make it a shared_ptr, so the policy object is securely deleted at run-time when all referencing caches are deleted.
* Small clean up of unused typedefs.