### PR TITLE
Add utility for cache set and line lock/unlock.

### DIFF
--- a/cache/cache.hpp
+++ b/cache/cache.hpp
@@ -45,8 +45,9 @@ template<int IW, int NW, typename MT, typename DT, bool EnMT>
   requires C_DERIVE<MT, CMMetadataCommon> && C_DERIVE_OR_VOID<DT, CMDataBase>
 class CacheArrayNorm : public CacheArrayBase
 {
+  typedef typename std::conditional<EnMT, MetaLock<MT>, MT>::type C_MT;
 protected:
-  std::vector<MT *> meta;   // meta array
+  std::vector<C_MT *> meta;   // meta array
   std::vector<DT *> data;   // data array, could be null
   const unsigned int way_num;
   std::vector<AtomicVar<uint16_t> > cache_set_state;  // record current transactions for multithread support
@@ -59,7 +60,7 @@ public:
     constexpr size_t data_num = nset * NW;
 
     meta.resize(meta_num);
-    for(auto &m:meta) m = new MT();
+    for(auto &m:meta) m = new C_MT();
     if(extra_way)
       for(unsigned int s=0; s<nset; s++)
         for(unsigned int w=NW; w<way_num; w++)

--- a/cache/cache_multi.hpp
+++ b/cache/cache_multi.hpp
@@ -21,11 +21,11 @@ public:
 template<int IW, int NW, typename MT, typename DT>
   requires C_DERIVE<MT, CMMetadataCommon> 
         && C_DERIVE_OR_VOID<DT, CMDataBase>
-class CacheArrayMultiThread : public CacheArrayNorm<IW, NW, MT, DT>, 
+class CacheArrayMultiThread : public CacheArrayNorm<IW, NW, MT, DT, true>, 
                               public CacheArrayMultiThreadSupport
 {
 
-  typedef CacheArrayNorm<IW, NW, MT, DT> CacheAT;
+  typedef CacheArrayNorm<IW, NW, MT, DT, true> CacheAT;
 protected:
   std::vector<uint32_t> status; // record every set status
   std::vector<std::mutex *> status_mtxs; // mutex for status

--- a/cache/coherence_multi.hpp
+++ b/cache/coherence_multi.hpp
@@ -15,10 +15,10 @@ public:
   static const uint16_t flush         = 0x001;
   static const uint16_t read          = 0x001;
   static const uint16_t write         = 0x001;
-  static const uint16_t probe         = 0x010;
+  static const uint16_t probe         = 0x010; // acquire miss, requiring lower cahce which back-probe this cache
   static const uint16_t evict         = 0x010;
   static const uint16_t evict_cv_wait = 0x100;
-  static const uint16_t release       = 0x100;
+  static const uint16_t release       = 0x100; // acquire hit but need back probe and writeback from inner
 };
 
 struct addr_info{

--- a/cache/mirage.hpp
+++ b/cache/mirage.hpp
@@ -119,7 +119,7 @@ public:
   MirageCache(std::string name = "") : CacheT(name, 1)
   { 
     // CacheMirage has P+1 CacheArray
-    arrays[P] = new CacheArrayNorm<IW,P*NW,DTMT,DT>(); // the separated data array
+    arrays[P] = new CacheArrayNorm<IW,P*NW,DTMT,DT,EnMT>(); // the separated data array
 
     // allocate data buffer pool as the DT given to CacheDkewed is void
     if constexpr (!C_VOID<DT>) {

--- a/util/multithread.hpp
+++ b/util/multithread.hpp
@@ -16,6 +16,9 @@ public:
   AtomicVar() : var(new std::atomic<T>()) {}
   AtomicVar(const T& v) : var(new std::atomic<T>(v)) {}
 
+  // to put AtomicVar into a runtime resizable vector, a copy constructor must be provided
+  AtomicVar(const AtomicVar<T>& v) : var(new std::atomic<T>(v.read())) {}
+
   __always_inline T read() const {
     return var->load();
   }


### PR DESCRIPTION
Before actually lock cache sets and cache lines, prepare the utilities to do so efficiently.