### PR TITLE
Thread safe print

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ $(PARALLEL_REGRESSION_TESTS_EXE): %:%.cpp $(CACHE_OBJS) $(UTIL_OBJS) $(CRYPTO_LI
 	$(CXX) $(CXXFLAGS) $< $(CACHE_OBJS) $(UTIL_OBJS) $(CRYPTO_LIB) -o $@
 
 $(PARALLEL_REGRESSION_TESTS_RST): %.out: %
-	$< 2>$@
+	$< 2>$@ 1>temp.log
 
 regression: $(REGRESSION_TESTS_RST) $(PARALLEL_REGRESSION_TESTS_RST)
 
@@ -87,7 +87,7 @@ libflexicas.a: $(CACHE_OBJS) $(UTIL_OBJS) $(CRYPTO_LIB)
 
 clean:
 	-$(MAKE) clean-regression
-	-$(MAKE) clean-parallel-regression
+	-$(MAKE) clean-parallel-regression temp.log
 	-rm $(UTIL_OBJS) $(CACHE_OBJS)
 
 .PHONY: clean

--- a/regression/multi-l2-msi.cpp
+++ b/regression/multi-l2-msi.cpp
@@ -24,24 +24,31 @@
 //#define TestN 512
 
 int main(){
-  auto l1d = cache_gen_multi_thread_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU_MT, MSIMultiThreadPolicy, false, false, void, false>(NCore, "l1d");
+  auto l1d = cache_gen_multi_thread_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU_MT, MSIMultiThreadPolicy, false, false, void, true>(NCore, "l1d");
   auto core_data = get_l1_core_interface(l1d);
-  auto l1i = cache_gen_multi_thread_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU_MT, MSIMultiThreadPolicy, false, true, void, false>(NCore, "l1i");
+  auto l1i = cache_gen_multi_thread_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU_MT, MSIMultiThreadPolicy, false, true, void, true>(NCore, "l1i");
   auto core_inst = get_l1_core_interface(l1i);
 
-  auto l2 = cache_gen_multi_thread_l2<L2IW, L2WN, Data64B, MetadataBroadcastBase, ReplaceLRU_MT, MSIMultiThreadPolicy, true, void, false>(1, "l2")[0];
-  auto mem = new SimpleMemoryModel<Data64B, void, false, true>("mem");
+  auto l2 = cache_gen_multi_thread_l2<L2IW, L2WN, Data64B, MetadataBroadcastBase, ReplaceLRU_MT, MSIMultiThreadPolicy, true, void, true>(1, "l2")[0];
+  auto mem = new SimpleMemoryModel<Data64B, void, true, true>("mem");
+  SimpleTracerMT tracer(true);
 
   for(int i=0; i<NCore; i++) {
     l1i[i]->outer->connect(l2->inner, l2->inner->connect(l1i[i]->outer, true));
     l1d[i]->outer->connect(l2->inner, l2->inner->connect(l1d[i]->outer));
+    l1i[i]->attach_monitor(&tracer);
+    l1d[i]->attach_monitor(&tracer);
   }
   l2->outer->connect(mem, mem->connect(l2->outer));
+
+  l2->attach_monitor(&tracer);
+  mem->attach_monitor(&tracer);
 
   ParallelRegressionGen<NCore, true, false, PAddrN, SAddrN, Data64B> tgen;
 
   tgen.run(TestN, &core_inst, &core_data);
 
+  tracer.stop();
   delete_caches(l1d);
   delete_caches(l1i);
   delete l2;

--- a/util/monitor.cpp
+++ b/util/monitor.cpp
@@ -9,50 +9,51 @@ static boost::format   write_fmt("%-10s write %016x %02d %04d %02d %1x");
 static boost::format invalid_fmt("%-10s evict %016x %02d %04d %02d  ");
 static boost::format    data_fmt("%016x");
 
+void SimpleTracer::print(const std::string& msg) {
+  std::cout << msg << std::endl;
+}
+
 void SimpleTracer::read(uint64_t cache_id, uint64_t addr, int32_t ai, int32_t s, int32_t w, bool hit, const CMMetadataBase *meta, const CMDataBase *data) {
-  std::cout << (read_fmt % UniqueID::name(cache_id) % addr % ai % s % w % hit);
+  std::string msg;  msg.reserve(100);
+  msg += (read_fmt % UniqueID::name(cache_id) % addr % ai % s % w % hit).str();
 
   if(meta)
-    std::cout << " [" << meta->to_string() << "]";
+    msg.append(" [").append(meta->to_string()).append("]");
   else if(data)
-    std::cout << "      ";
+    msg.append("      ");
 
-  if(data) {
-    std::cout << " ";
-    if(compact_data) std::cout << (data_fmt % (data->read(0)));
-    else             std::cout << data->to_string();
-  }
-  std::cout << std::endl;
+  if(data)
+    msg.append(" ").append(compact_data ? (data_fmt % (data->read(0))).str() : data->to_string());
+
+  print(msg);
 }
 
 void SimpleTracer::write(uint64_t cache_id, uint64_t addr, int32_t ai, int32_t s, int32_t w, bool hit, const CMMetadataBase *meta, const CMDataBase *data) {
-  std::cout << (write_fmt % UniqueID::name(cache_id) % addr % ai % s % w % hit);
+  std::string msg;  msg.reserve(100);
+  msg += (write_fmt % UniqueID::name(cache_id) % addr % ai % s % w % hit).str();
 
   if(meta)
-    std::cout << " [" << meta->to_string() << "]";
+    msg.append(" [").append(meta->to_string()).append("]");
   else if(data)
-    std::cout << "      ";
+    msg.append("      ");
 
-  if(data) {
-    std::cout << " ";
-    if(compact_data) std::cout << (data_fmt % (data->read(0)));
-    else             std::cout << data->to_string();
-  }
-  std::cout << std::endl;
+  if(data)
+    msg.append(" ").append(compact_data ? (data_fmt % (data->read(0))).str() : data->to_string());
+
+  print(msg);
 }
 
 void SimpleTracer::invalid(uint64_t cache_id, uint64_t addr, int32_t ai, int32_t s, int32_t w, const CMMetadataBase *meta, const CMDataBase *data) {
-  std::cout << (invalid_fmt % UniqueID::name(cache_id) % addr % ai % s % w) ;
+  std::string msg;  msg.reserve(100);
+  msg += (invalid_fmt % UniqueID::name(cache_id) % addr % ai % s % w).str() ;
 
   if(meta)
-    std::cout << " [" << meta->to_string() << "]";
+    msg.append(" [").append(meta->to_string()).append("]");
   else if(data)
-    std::cout << "      ";
+    msg.append("      ");
 
-  if(data) {
-    std::cout << " ";
-    if(compact_data) std::cout << (data_fmt % (data->read(0)));
-    else             std::cout << data->to_string();
-  }
-  std::cout << std::endl;
+  if(data)
+    msg.append(" ").append(compact_data ? (data_fmt % (data->read(0))).str() : data->to_string());
+
+  print(msg);
 }

--- a/util/monitor.cpp
+++ b/util/monitor.cpp
@@ -4,18 +4,13 @@
 #include <boost/format.hpp>
 #include "cache/metadata.hpp"
 
-static boost::format    read_fmt("%-10s read  %016x %02d %04d %02d %1x");
-static boost::format   write_fmt("%-10s write %016x %02d %04d %02d %1x");
-static boost::format invalid_fmt("%-10s evict %016x %02d %04d %02d  ");
-static boost::format    data_fmt("%016x");
-
-void SimpleTracer::print(const std::string& msg) {
+void SimpleTracer::print(std::string& msg) {
   std::cout << msg << std::endl;
 }
 
 void SimpleTracer::read(uint64_t cache_id, uint64_t addr, int32_t ai, int32_t s, int32_t w, bool hit, const CMMetadataBase *meta, const CMDataBase *data) {
   std::string msg;  msg.reserve(100);
-  msg += (read_fmt % UniqueID::name(cache_id) % addr % ai % s % w % hit).str();
+  msg += (boost::format("%-10s read  %016x %02d %04d %02d %1x") % UniqueID::name(cache_id) % addr % ai % s % w % hit).str();
 
   if(meta)
     msg.append(" [").append(meta->to_string()).append("]");
@@ -23,14 +18,14 @@ void SimpleTracer::read(uint64_t cache_id, uint64_t addr, int32_t ai, int32_t s,
     msg.append("      ");
 
   if(data)
-    msg.append(" ").append(compact_data ? (data_fmt % (data->read(0))).str() : data->to_string());
+    msg.append(" ").append(compact_data ? (boost::format("%016x") % (data->read(0))).str() : data->to_string());
 
   print(msg);
 }
 
 void SimpleTracer::write(uint64_t cache_id, uint64_t addr, int32_t ai, int32_t s, int32_t w, bool hit, const CMMetadataBase *meta, const CMDataBase *data) {
   std::string msg;  msg.reserve(100);
-  msg += (write_fmt % UniqueID::name(cache_id) % addr % ai % s % w % hit).str();
+  msg += (boost::format("%-10s write %016x %02d %04d %02d %1x") % UniqueID::name(cache_id) % addr % ai % s % w % hit).str();
 
   if(meta)
     msg.append(" [").append(meta->to_string()).append("]");
@@ -38,14 +33,14 @@ void SimpleTracer::write(uint64_t cache_id, uint64_t addr, int32_t ai, int32_t s
     msg.append("      ");
 
   if(data)
-    msg.append(" ").append(compact_data ? (data_fmt % (data->read(0))).str() : data->to_string());
+    msg.append(" ").append(compact_data ? (boost::format("%016x") % (data->read(0))).str() : data->to_string());
 
   print(msg);
 }
 
 void SimpleTracer::invalid(uint64_t cache_id, uint64_t addr, int32_t ai, int32_t s, int32_t w, const CMMetadataBase *meta, const CMDataBase *data) {
   std::string msg;  msg.reserve(100);
-  msg += (invalid_fmt % UniqueID::name(cache_id) % addr % ai % s % w).str() ;
+  msg += (boost::format("%-10s evict %016x %02d %04d %02d  ") % UniqueID::name(cache_id) % addr % ai % s % w).str() ;
 
   if(meta)
     msg.append(" [").append(meta->to_string()).append("]");
@@ -53,7 +48,7 @@ void SimpleTracer::invalid(uint64_t cache_id, uint64_t addr, int32_t ai, int32_t
     msg.append("      ");
 
   if(data)
-    msg.append(" ").append(compact_data ? (data_fmt % (data->read(0))).str() : data->to_string());
+    msg.append(" ").append(compact_data ? (boost::format("%016x") % (data->read(0))).str() : data->to_string());
 
   print(msg);
 }

--- a/util/monitor.hpp
+++ b/util/monitor.hpp
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <set>
+#include <string>
 #include "util/delay.hpp"
 #include "util/concept_macro.hpp"
 
@@ -170,6 +171,9 @@ class SimpleTracer : public MonitorBase
 {
   bool active;
   bool compact_data;
+
+  virtual void print(const std::string& msg);
+
 public:
   SimpleTracer(bool cd = false): active(true), compact_data(cd) {}
   virtual ~SimpleTracer() {}

--- a/util/multithread.hpp
+++ b/util/multithread.hpp
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <condition_variable>
 #include <memory>
+#include <chrono>
 
 template<typename T>
 class AtomicVar {
@@ -23,8 +24,9 @@ public:
     return var->load();
   }
 
-  __always_inline void write(T v) {
+  __always_inline void write(T v, bool notify = false) {
     var->store(v);
+    if(notify) cv.notify_all();
   }
 
   __always_inline bool swap(T& expect, T v, bool notify = false) {
@@ -39,6 +41,12 @@ public:
   __always_inline void wait() {
     std::unique_lock lk(mtx);
     cv.wait(lk);
+  }
+
+  __always_inline void wait_timeout() {
+    using namespace std::chrono_literals;
+    std::unique_lock lk(mtx);
+    cv.wait_for(lk, 10us);
   }
 };
 

--- a/util/print.hpp
+++ b/util/print.hpp
@@ -1,0 +1,54 @@
+#ifndef CM_UTIL_PRINT_HPP_
+#define CM_UTIL_PRINT_HPP_
+
+#include <string>
+#include <vector>
+#include <utility>
+#include <iostream>
+#include "util/multithread.hpp"
+
+class PrintPool {
+  const int pool_size;
+  AtomicVar<int> pw, pr;
+  std::vector<std::string>      pool;
+  std::vector<AtomicVar<bool> > valid;
+  AtomicVar<bool> finish;
+public:
+  PrintPool(int pool_size) : pool_size(pool_size), pw(0), pr(0), pool(pool_size), valid(pool_size, false), finish(false) {}
+
+  std::pair<std::string *, AtomicVar<bool> *> allocate() {
+    while(true) {
+      auto index = pw.read();
+      if(valid[index].read()) pr.wait(); // full, wait
+      if(pw.swap(index, (index + 1)%pool_size)) return std::pair(&(pool[index]), &(valid[index]));
+    }
+  }
+
+  // a safer but might slower way of print a message
+  void add(std::string& msg) {
+    auto [buf, flag] = allocate();
+    *buf = msg;
+    flag->write(true, true);
+  }
+
+  void stop() { finish.write(true); }
+
+  void sync(){ // wait until all existing messages are printed
+  auto index = (pw.read() + pool_size - 1) % pool_size;
+  while(index != pr.read()) pr.wait();
+  while(valid[index].read() != false) valid[index].wait();
+  }
+
+  void print() { // start print the pool
+    auto index = pr.read();
+    while(!finish.read()) {
+      if(!valid[index].read()) { valid[index].wait_timeout(); continue; }
+      std::cout << pool[index] << std::endl;
+      valid[index].write(false, true);
+      index = (index + 1) % pool_size;
+      pr.write(index, true);
+    }
+  }
+};
+
+#endif


### PR DESCRIPTION
For debugging the multithread simulation case, a thread-safe printer is required and is now implemented.