### PR TITLE
add a lock checker for debugging multithread simulation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,16 +11,16 @@ CXXSTD = --std=c++17 -fconcepts
 
 ifeq ($(MODE), release)
     CXXFLAGS = $(CXXSTD) -O3 -DNDEBUG -I. -fPIC
+	REGRESS_LD_FLAGS =
 else ifeq ($(MODE), debug)
-    CXXFLAGS = $(CXXSTD) -O0 -g -I. -fPIC
+    CXXFLAGS = $(CXXSTD) -O0 -g -I. -fPIC -DCHECK_MULTI
+	REGRESS_LD_FLAGS =
+else ifeq ($(MODE), debug-multi)
+    CXXFLAGS = $(CXXSTD) -O0 -g -I. -fPIC -DCHECK_MULTI -DBOOST_STACKTRACE_LINK -DBOOST_STACKTRACE_USE_BACKTRACE
+	REGRESS_LD_FLAGS = -lboost_stacktrace_backtrace -ldl -lbacktrace
 else
     CXXFLAGS = $(CXXSTD) -O2 -I. -fPIC
-endif
-
-ifeq ($(MODE), debug)
-    DSLCXXFLAGS = $(CXXSTD) -O1 -g -I. -fPIC
-else
-    DSLCXXFLAGS = $(CXXSTD) -O2 -I. -fPIC
+	REGRESS_LD_FLAGS =
 endif
 
 UTIL_HEADERS  = $(wildcard util/*.hpp)
@@ -69,7 +69,7 @@ PARALLEL_REGRESSION_TESTS_EXE = $(patsubst %, regression/%, $(PARALLEL_REGRESSIO
 PARALLEL_REGRESSION_TESTS_RST = $(patsubst %, regression/%.out, $(PARALLEL_REGRESSION_TESTS))
 
 $(PARALLEL_REGRESSION_TESTS_EXE): %:%.cpp $(CACHE_OBJS) $(UTIL_OBJS) $(CRYPTO_LIB) $(CACHE_HEADERS)
-	$(CXX) $(CXXFLAGS) $< $(CACHE_OBJS) $(UTIL_OBJS) $(CRYPTO_LIB) -o $@
+	$(CXX) $(CXXFLAGS) $< $(CACHE_OBJS) $(UTIL_OBJS) $(CRYPTO_LIB) $(REGRESS_LD_FLAGS) -o $@
 
 $(PARALLEL_REGRESSION_TESTS_RST): %.out: %
 	timeout 1m $< 2>$@ 1>temp.log

--- a/regression/multi-l2-msi.cpp
+++ b/regression/multi-l2-msi.cpp
@@ -23,6 +23,11 @@
 //#define SAddrN 64
 //#define TestN 512
 
+PrintPool *globalPrinter;
+#ifdef CHECK_MULTI
+  LockCheck * global_lock_checker = new LockCheck;
+#endif
+
 int main(){
   auto l1d = cache_gen_multi_thread_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU_MT, MSIMultiThreadPolicy, false, false, void, true>(NCore, "l1d");
   auto core_data = get_l1_core_interface(l1d);
@@ -31,6 +36,7 @@ int main(){
 
   auto l2 = cache_gen_multi_thread_l2<L2IW, L2WN, Data64B, MetadataBroadcastBase, ReplaceLRU_MT, MSIMultiThreadPolicy, true, void, true>(1, "l2")[0];
   auto mem = new SimpleMemoryModel<Data64B, void, true, true>("mem");
+  globalPrinter = new PrintPool(256);
   SimpleTracerMT tracer(true);
 
   for(int i=0; i<NCore; i++) {

--- a/util/monitor.hpp
+++ b/util/monitor.hpp
@@ -238,20 +238,19 @@ public:
 // multithread version of simple tracer
 class SimpleTracerMT : public SimpleTracer
 {
-  PrintPool pool;
   std::thread print_thread;
   std::hash<std::thread::id> hasher;
   virtual void print(std::string& msg) {
     uint16_t id = hasher(std::this_thread::get_id());
     std::string msg_ext = (boost::format("thread %04x: %s") % id % msg).str();
-    pool.add(msg_ext);
+    globalPrinter->add(msg_ext);
   }
 
 public:
-  SimpleTracerMT(bool cd = false): SimpleTracer(cd), pool(256) {
-    print_thread = std::thread(&PrintPool::print, &pool);
+  SimpleTracerMT(bool cd = false): SimpleTracer(cd){
+    print_thread = std::thread(&PrintPool::print, globalPrinter);
   }
-  virtual void stop() { pool.stop(); print_thread.join(); }
+  virtual void stop() { globalPrinter->stop(); print_thread.join(); }
 };
 
 #endif

--- a/util/print.hpp
+++ b/util/print.hpp
@@ -7,7 +7,6 @@
 #include <iostream>
 #include "util/multithread.hpp"
 
-
 // can be implemented using std::osyncstream after C++20
 class PrintPool {
   const int pool_size;
@@ -52,5 +51,12 @@ public:
     }
   }
 };
+
+extern PrintPool *globalPrinter;
+
+inline void global_print(std::string msg) {
+  if(globalPrinter) globalPrinter->add(msg);
+  else std::cout << msg << std::endl;
+}
 
 #endif


### PR DESCRIPTION
`MODE=debug make regression` will enable cache line lock checker.
`MODE=debug-multi make regression` will enable extra capability to print out stacktrace (using boost::stacktrace).