### PR TITLE
bugfix for replacer's alloc_map

### DIFF
--- a/cache/cache.hpp
+++ b/cache/cache.hpp
@@ -162,7 +162,7 @@ public:
     return hit(addr, &ai, &s, &w, 0, false);
   }
 
-  virtual void replace(uint64_t addr, uint32_t *ai, uint32_t *s, uint32_t *w, unsigned int genre = 0) = 0;
+  virtual void replace(uint64_t addr, uint32_t *ai, uint32_t *s, uint32_t *w, uint16_t prio, unsigned int genre = 0) = 0;
   virtual void replace_restore(uint32_t ai, uint32_t s, uint32_t w) = 0;
 
   __always_inline CMMetadataCommon *access(uint32_t ai, uint32_t s, uint32_t w) { return arrays[ai]->get_meta(s, w); }
@@ -266,10 +266,11 @@ public:
       return std::make_pair(meta, nullptr);
   }
 
-  virtual void replace(uint64_t addr, uint32_t *ai, uint32_t *s, uint32_t *w, unsigned int genre = 0) override {
+  virtual void replace(uint64_t addr, uint32_t *ai, uint32_t *s, uint32_t *w, uint16_t prio, unsigned int genre = 0) override {
     if constexpr (P==1) *ai = 0;
     else                *ai = ((*loc_random)() % P);
     *s = indexer.index(addr, *ai);
+    if(EnMT) this->set_mt_state(*ai, *s, prio);
     replacer[*ai].replace(*s, w);
   }
 

--- a/cache/cache.hpp
+++ b/cache/cache.hpp
@@ -162,8 +162,7 @@ public:
     return hit(addr, &ai, &s, &w, 0, false);
   }
 
-  virtual void replace(uint64_t addr, uint32_t *ai, uint32_t *s, uint32_t *w, uint16_t prio, unsigned int genre = 0) = 0;
-  virtual void replace_restore(uint32_t ai, uint32_t s, uint32_t w) = 0;
+  virtual bool replace(uint64_t addr, uint32_t *ai, uint32_t *s, uint32_t *w, uint16_t prio, unsigned int genre = 0) = 0;
 
   __always_inline CMMetadataCommon *access(uint32_t ai, uint32_t s, uint32_t w) { return arrays[ai]->get_meta(s, w); }
   __always_inline CMDataBase *get_data(uint32_t ai, uint32_t s, uint32_t w) { return arrays[ai]->get_data(s, w); }
@@ -199,7 +198,7 @@ public:
 template<int IW, int NW, int P, typename MT, typename DT, typename IDX, typename RPC, typename DLY,
          bool EnMon, bool EF = true, bool EnMT = false, int MSHR = 4>
   requires C_DERIVE<MT, CMMetadataBase> && C_DERIVE_OR_VOID<DT, CMDataBase> &&
-           C_DERIVE<IDX, IndexFuncBase> && C_DERIVE<RPC, ReplaceFuncBase<EF, EnMT> > && C_DERIVE_OR_VOID<DLY, DelayBase> &&
+           C_DERIVE<IDX, IndexFuncBase> && C_DERIVE<RPC, ReplaceFuncBase<EF> > && C_DERIVE_OR_VOID<DLY, DelayBase> &&
            (MSHR >= 2) // 2 buffers are required even for single-thread simulation
 class CacheSkewed : public CacheBase
 {
@@ -266,16 +265,20 @@ public:
       return std::make_pair(meta, nullptr);
   }
 
-  virtual void replace(uint64_t addr, uint32_t *ai, uint32_t *s, uint32_t *w, uint16_t prio, unsigned int genre = 0) override {
+  virtual bool replace(uint64_t addr, uint32_t *ai, uint32_t *s, uint32_t *w, uint16_t prio, unsigned int genre = 0) override {
     if constexpr (P==1) *ai = 0;
     else                *ai = ((*loc_random)() % P);
     *s = indexer.index(addr, *ai);
-    if(EnMT) this->set_mt_state(*ai, *s, prio);
+    if(EnMT) {
+      this->set_mt_state(*ai, *s, prio);
+      // double check the miss status
+      if(CacheBase::hit(addr)) { // the exact cache block is re-inserted by other transactions
+        this->reset_mt_state(*ai, *s, prio);
+        return false;
+      }
+    }
     replacer[*ai].replace(*s, w);
-  }
-
-  virtual void replace_restore(uint32_t ai, uint32_t s, uint32_t w) override {
-    replacer[ai].restore(s, w);
+    return true;
   }
 
   virtual void hook_read(uint64_t addr, uint32_t ai, uint32_t s, uint32_t w, bool hit, const CMMetadataBase * meta, const CMDataBase *data, uint64_t *delay) override {

--- a/cache/coherence.hpp
+++ b/cache/coherence.hpp
@@ -278,7 +278,7 @@ protected:
             continue; // redo the hit check
           }
         } else { // do the replacement selection and recheck hit status
-          cache->replace(addr, &ai, &s, &w); cache->set_mt_state(ai, s, prio);
+          cache->replace(addr, &ai, &s, &w, prio);
           std::tie(meta, data) = cache->access_line(ai, s, w); meta->lock();
           if(cache->hit(addr)) { // cache line is re-inserted by other transactions
             cache->replace_restore(ai, s, w);
@@ -291,7 +291,7 @@ protected:
       }
     } else {
       hit = cache->hit(addr, &ai, &s, &w);
-      if(!hit) cache->replace(addr, &ai, &s, &w);
+      if(!hit) cache->replace(addr, &ai, &s, &w, prio);
       std::tie(meta, data) = cache->access_line(ai, s, w);
     }
 

--- a/cache/coherence.hpp
+++ b/cache/coherence.hpp
@@ -277,15 +277,12 @@ protected:
             cache->reset_mt_state(ai, s, prio);
             continue; // redo the hit check
           }
-        } else { // do the replacement selection and recheck hit status
-          cache->replace(addr, &ai, &s, &w, prio);
-          std::tie(meta, data) = cache->access_line(ai, s, w); meta->lock();
-          if(cache->hit(addr)) { // cache line is re-inserted by other transactions
-            cache->replace_restore(ai, s, w);
-            meta->unlock(); meta = nullptr; data = nullptr;
-            cache->reset_mt_state(ai, s, prio);
+        } else { // miss
+          if(cache->replace(addr, &ai, &s, &w, prio)) { // lock the cache set and get a replacement candidate
+            std::tie(meta, data) = cache->access_line(ai, s, w);
+            meta->lock();
+          } else
             continue; // redo the hit check
-          }
         }
         break;
       }

--- a/cache/exclusive.hpp
+++ b/cache/exclusive.hpp
@@ -139,7 +139,7 @@ public:
   CacheSkewedExclusive(std::string name = "") : CacheT(name, 0, (EnDir ? DW : 0)) {}
   virtual ~CacheSkewedExclusive() override {}
 
-  virtual void replace(uint64_t addr, uint32_t *ai, uint32_t *s, uint32_t *w, uint16_t prio, unsigned int genre = 0) override {
+  virtual bool replace(uint64_t addr, uint32_t *ai, uint32_t *s, uint32_t *w, uint16_t prio, unsigned int genre = 0) override {
     if constexpr (!EnDir) CacheT::replace(addr, ai, s, w, prio, 0);
     else {
       if(0 == genre) CacheT::replace(addr, ai, s, w, prio, 0);
@@ -151,6 +151,7 @@ public:
         *w += NW;
       }
     }
+    return true; // ToDo: support multithread
   }
 
   virtual void hook_read(uint64_t addr, uint32_t ai, uint32_t s, uint32_t w, bool hit, const CMMetadataBase *meta, const CMDataBase *data, uint64_t *delay) override {

--- a/cache/exclusive.hpp
+++ b/cache/exclusive.hpp
@@ -139,10 +139,10 @@ public:
   CacheSkewedExclusive(std::string name = "") : CacheT(name, 0, (EnDir ? DW : 0)) {}
   virtual ~CacheSkewedExclusive() override {}
 
-  virtual void replace(uint64_t addr, uint32_t *ai, uint32_t *s, uint32_t *w, unsigned int genre = 0) override {
-    if constexpr (!EnDir) CacheT::replace(addr, ai, s, w, 0);
+  virtual void replace(uint64_t addr, uint32_t *ai, uint32_t *s, uint32_t *w, uint16_t prio, unsigned int genre = 0) override {
+    if constexpr (!EnDir) CacheT::replace(addr, ai, s, w, prio, 0);
     else {
-      if(0 == genre) CacheT::replace(addr, ai, s, w, 0);
+      if(0 == genre) CacheT::replace(addr, ai, s, w, prio, 0);
       else {
         if constexpr (P==1) *ai = 0;
         else                *ai = ((*loc_random)() % P);
@@ -269,7 +269,7 @@ protected:
       auto probe_hit = fetch_line(addr, meta, data, cmd, delay);
       if(cmd.id == -1 && !probe_hit) { // need to reserve a place in the normal way if there no cached copy
         uint32_t mai, ms, mw;
-        cache->replace(addr, &mai, &ms, &mw);
+        cache->replace(addr, &mai, &ms, &mw, XactPrio::acquire);
         auto [mmeta, mdata] = cache->access_line(mai, ms, mw);
         if(mmeta->is_valid()) this->evict(mmeta, mdata, mai, ms, mw, delay);
         mmeta->init(addr); mmeta->copy(meta); meta->to_invalid();
@@ -313,7 +313,7 @@ protected:
     }
 
     if(!probe_hit) { // exclusive cache handles a release only when there is no other sharer
-      cache->replace(addr, &ai, &s, &w);
+      cache->replace(addr, &ai, &s, &w, XactPrio::release);
       std::tie(meta, data) = cache->access_line(ai, s, w);
       if(meta->is_valid()) this->evict(meta, data, ai, s, w, delay);
       if(data_inner && data) data->copy(data_inner);
@@ -401,9 +401,9 @@ public:
 
 protected:
   std::tuple<CMMetadataBase *, CMDataBase *, uint32_t, uint32_t, uint32_t>
-  replace_line_ext(uint64_t addr, uint64_t *delay) {
+  replace_line_ext(uint64_t addr, uint16_t prio, uint64_t *delay) {
     uint32_t ai, s, w;
-    cache->replace(addr, &ai, &s, &w, true);
+    cache->replace(addr, &ai, &s, &w, prio, true);
     auto [meta, data] = cache->access_line(ai, s, w);
     data = cache->data_copy_buffer();
     if(meta->is_valid()) this->evict(meta, data, ai, s, w, delay);
@@ -432,7 +432,7 @@ protected:
         else { // normal request, move it to an extended way
           if(meta->is_dirty()) // writeback the dirty data as the dirty bit would be lost
             outer->writeback_req(addr, meta, data, policy->cmd_for_outer_writeback(cmd), delay);
-          auto [mmeta, mdata, mai, ms, mw] = replace_line_ext(addr, delay);
+          auto [mmeta, mdata, mai, ms, mw] = replace_line_ext(addr, prio, delay);
           mmeta->init(addr); mmeta->copy(meta); meta->to_invalid();
           return std::make_tuple(mmeta, data, mai, ms, mw, hit);
         }
@@ -463,11 +463,11 @@ protected:
       }
     } else { // miss
       if(cmd.id == -1) { // request from an uncached inner, fetch to a normal way
-        cache->replace(addr, &ai, &s, &w);
+        cache->replace(addr, &ai, &s, &w, prio);
         std::tie(meta, data) = cache->access_line(ai, s, w);
         if(meta->is_valid()) this->evict(meta, data, ai, s, w, delay);
       } else { // normal request, fetch to an extended way
-        std::tie(meta, data, ai, s, w) = replace_line_ext(addr, delay);
+        std::tie(meta, data, ai, s, w) = replace_line_ext(addr, prio, delay);
         data = cache->data_copy_buffer();
       }
       outer->acquire_req(addr, meta, data, policy->cmd_for_outer_acquire(cmd), delay); // fetch the missing block
@@ -504,7 +504,7 @@ protected:
       if(!phit) { // exclusive cache handles a release only when there is no other sharer
         // move it to normal meta
         uint32_t mai, ms, mw;
-        cache->replace(addr, &mai, &ms, &mw);
+        cache->replace(addr, &mai, &ms, &mw, XactPrio::release);
         auto [mmeta, mdata] = cache->access_line(mai, ms, mw);
         if(mmeta->is_valid()) this->evict(mmeta, mdata, mai, ms, mw, delay);
         mmeta->init(addr); mmeta->copy(meta); meta->to_invalid();

--- a/cache/mirage.hpp
+++ b/cache/mirage.hpp
@@ -157,7 +157,7 @@ public:
     return std::make_pair(d_s, d_w);
   }
 
-  virtual void replace(uint64_t addr, uint32_t *ai, uint32_t *s, uint32_t *w, unsigned int genre = 0) override {
+  virtual void replace(uint64_t addr, uint32_t *ai, uint32_t *s, uint32_t *w, uint16_t prio, unsigned int genre = 0) override {
     int max_free = -1, p = 0;
     std::vector<std::pair<uint32_t, uint32_t> > candidates(P);
     uint32_t m_s;
@@ -262,7 +262,7 @@ protected:
       else if(promote_local) meta->to_modified(-1);
     } else { // miss
       // do the cuckoo replacement
-      cache->replace(addr, &ai, &s, &w);
+      cache->replace(addr, &ai, &s, &w, prio);
       meta = static_cast<CMMetadataBase *>(cache->access(ai, s, w));
       std::stack<std::tuple<uint32_t, uint32_t, uint32_t> > stack;
       if(meta->is_valid()) cache->cuckoo_search(&ai, &s, &w, meta, stack);

--- a/cache/mirage.hpp
+++ b/cache/mirage.hpp
@@ -92,7 +92,7 @@ template<int IW, int NW, int EW, int P, int MaxRelocN, typename MT, typename DT,
          bool EF = true, bool EnMT = false, int MSHR = 4>
   requires C_DERIVE<MT, MetadataBroadcastBase, MirageMetadataSupport> && C_DERIVE_OR_VOID<DT, CMDataBase> &&
            C_DERIVE<DTMT, MirageDataMeta>  && C_DERIVE<MIDX, IndexFuncBase>   && C_DERIVE<DIDX, IndexFuncBase> &&
-           C_DERIVE<MRPC, ReplaceFuncBase<EF,false> > && C_DERIVE<DRPC, ReplaceFuncBase<EF,false> > && C_DERIVE_OR_VOID<DLY, DelayBase>
+           C_DERIVE<MRPC, ReplaceFuncBase<EF> > && C_DERIVE<DRPC, ReplaceFuncBase<EF> > && C_DERIVE_OR_VOID<DLY, DelayBase>
 class MirageCache : public CacheSkewed<IW, NW+EW, P, MT, void, MIDX, MRPC, DLY, EnMon, EF, EnMT, MSHR>
 {
 // see: https://www.usenix.org/system/files/sec21fall-saileshwar.pdf
@@ -157,7 +157,7 @@ public:
     return std::make_pair(d_s, d_w);
   }
 
-  virtual void replace(uint64_t addr, uint32_t *ai, uint32_t *s, uint32_t *w, uint16_t prio, unsigned int genre = 0) override {
+  virtual bool replace(uint64_t addr, uint32_t *ai, uint32_t *s, uint32_t *w, uint16_t prio, unsigned int genre = 0) override {
     int max_free = -1, p = 0;
     std::vector<std::pair<uint32_t, uint32_t> > candidates(P);
     uint32_t m_s;
@@ -170,6 +170,7 @@ public:
     }
     std::tie(*ai, *s) = candidates[(*loc_random)() % p];
     replacer[*ai].replace(*s, w);
+    return true; // ToDo: support multithread
   }
 
   virtual void hook_read(uint64_t addr, uint32_t ai, uint32_t s, uint32_t w, bool hit, const CMMetadataBase * meta, const CMDataBase *data, uint64_t *delay) override {


### PR DESCRIPTION
这个PR试图修复如下几个问题：
问题1：alloc_map没有对alloc前的状态做区分.这导致如果先发生replace（将alloc_map[s][w]设为true），再发生restore时，一定会把free_map[s][w]设为true，但实际上这一路有可能之前已经正在被使用（即原来的free_map[s][w]为false），这种情况下free_map[s][w]不应该设为true

问题2：在access_line发生miss时，先发生replace，再将使用的set上锁.这可能会导致如下的错误：一个线程X在L2先发生了replace，想要驱逐的地址为A，并把A的alloc_map设为true，另一个线程Y在L2访问地址A，它在X发生replace后拿到A对应的访问权，之后执行hook_read函数并触发replacer的access函数，由于A的alloc_map为true，因此将A的alloc_map改为false，之后线程X拿到A set的访问权，它会首先执行replacer的invalid函数，由于它看到alloc_map为false，它将A对应的free_map设为true，这就导致了A其实正在被使用，但free_map为true的错误.因此在发生replace时要先对set上锁.


问题3：有这样一种情况：地址A在L1 X中为S状态，之后X想写地址A，它将L1 X中A对应的set上锁和A的meta都上锁，之后Y对A进行probe，它先拿到set的访问权，再等待meta A的锁，之后X由于向L2发起acquire请求，将A的meta解锁，Y将A的meta设为invalid并把地址A的free_map设为true，X从L2返回后执行access函数不会修改A的free_map，这也导致了A正在被使用,但free_map为true的错误，目前想到的办法是在access函数中加入对free_map的判断，但我感觉可能会让刚看代码的人觉得很疑惑（即为什么在access函数还要判断free_map的状态)