### PR TITLE
utilizing C++11 std features to simplify code

### DIFF
--- a/cache/coh_policy.hpp
+++ b/cache/coh_policy.hpp
@@ -45,41 +45,37 @@ public:
   __always_inline void connect(CohPolicyBase *policy) { outer = policy ? policy : this; } // memory does not use policy and returns nullptr
 
   // message type
-  __always_inline bool is_acquire(coh_cmd_t cmd) const     { return cmd.msg == acquire_msg;     }
-  __always_inline bool is_release(coh_cmd_t cmd) const     { return cmd.msg == release_msg;     }
-  __always_inline bool is_probe(coh_cmd_t cmd) const       { return cmd.msg == probe_msg;       }
-  __always_inline bool is_flush(coh_cmd_t cmd) const       { return cmd.msg == flush_msg;       }
-  __always_inline bool is_finish(coh_cmd_t cmd) const      { return cmd.msg == finish_msg;      }
+  constexpr __always_inline bool is_acquire(coh_cmd_t cmd) const     { return cmd.msg == acquire_msg;     }
+  constexpr __always_inline bool is_release(coh_cmd_t cmd) const     { return cmd.msg == release_msg;     }
+  constexpr __always_inline bool is_probe(coh_cmd_t cmd) const       { return cmd.msg == probe_msg;       }
+  constexpr __always_inline bool is_flush(coh_cmd_t cmd) const       { return cmd.msg == flush_msg;       }
+  constexpr __always_inline bool is_finish(coh_cmd_t cmd) const      { return cmd.msg == finish_msg;      }
 
   // action type
-  __always_inline bool is_fetch_read(coh_cmd_t cmd) const      { return cmd.act == fetch_read_act;  }
-  __always_inline bool is_fetch_write(coh_cmd_t cmd) const     { return cmd.act == fetch_write_act; }
-  __always_inline bool is_evict(coh_cmd_t cmd) const           { return cmd.act == evict_act;       }
-  __always_inline bool is_outer_evict(coh_cmd_t cmd) const     { return outer->is_evict(cmd);       }
-  __always_inline bool is_writeback(coh_cmd_t cmd) const       { return cmd.act == writeback_act;   }
-  __always_inline bool is_outer_writeback(coh_cmd_t cmd) const { return outer->is_writeback(cmd);   }
-  __always_inline bool is_downgrade(coh_cmd_t cmd) const       { return cmd.act == downgrade_act;   }
-  __always_inline bool is_write(coh_cmd_t cmd) const           { return cmd.act == fetch_write_act || cmd.act == evict_act || cmd.act == writeback_act; }
+  constexpr __always_inline bool is_fetch_read(coh_cmd_t cmd) const  { return cmd.act == fetch_read_act;  }
+  constexpr __always_inline bool is_fetch_write(coh_cmd_t cmd) const { return cmd.act == fetch_write_act; }
+  constexpr __always_inline bool is_evict(coh_cmd_t cmd) const       { return cmd.act == evict_act;       }
+  constexpr __always_inline bool is_writeback(coh_cmd_t cmd) const   { return cmd.act == writeback_act;   }
+  constexpr __always_inline bool is_downgrade(coh_cmd_t cmd) const   { return cmd.act == downgrade_act;   }
+  constexpr __always_inline bool is_write(coh_cmd_t cmd) const       { return cmd.act == fetch_write_act || cmd.act == evict_act || cmd.act == writeback_act; }
 
   // generate command
-  constexpr coh_cmd_t cmd_for_read()              const { return {-1, acquire_msg, fetch_read_act }; }
-  constexpr coh_cmd_t cmd_for_write()             const { return {-1, acquire_msg, fetch_write_act}; }
-  constexpr coh_cmd_t cmd_for_flush()             const { return {-1, flush_msg,   evict_act      }; }
-  constexpr coh_cmd_t cmd_for_writeback()         const { return {-1, flush_msg,   writeback_act  }; }
-  constexpr coh_cmd_t cmd_for_release()           const { return {-1, release_msg, evict_act      }; }
-  constexpr coh_cmd_t cmd_for_release_writeback() const { return {-1, release_msg, writeback_act  }; }
-  constexpr coh_cmd_t cmd_for_null()              const { return {-1, 0,           0              }; }
-  constexpr coh_cmd_t cmd_for_probe_writeback()   const { return {-1, probe_msg,   writeback_act  }; }
-  constexpr coh_cmd_t cmd_for_probe_release()     const { return {-1, probe_msg,   evict_act      }; }
-  constexpr coh_cmd_t cmd_for_probe_downgrade()   const { return {-1, probe_msg,   downgrade_act  }; }
+  constexpr __always_inline coh_cmd_t cmd_for_read()              const { return {-1, acquire_msg, fetch_read_act }; }
+  constexpr __always_inline coh_cmd_t cmd_for_write()             const { return {-1, acquire_msg, fetch_write_act}; }
+  constexpr __always_inline coh_cmd_t cmd_for_flush()             const { return {-1, flush_msg,   evict_act      }; }
+  constexpr __always_inline coh_cmd_t cmd_for_writeback()         const { return {-1, flush_msg,   writeback_act  }; }
+  constexpr __always_inline coh_cmd_t cmd_for_release()           const { return {-1, release_msg, evict_act      }; }
+  constexpr __always_inline coh_cmd_t cmd_for_release_writeback() const { return {-1, release_msg, writeback_act  }; }
+  constexpr __always_inline coh_cmd_t cmd_for_null()              const { return {-1, 0,           0              }; }
+  constexpr __always_inline coh_cmd_t cmd_for_probe_writeback()   const { return {-1, probe_msg,   writeback_act  }; }
+  constexpr __always_inline coh_cmd_t cmd_for_probe_release()     const { return {-1, probe_msg,   evict_act      }; }
+  constexpr __always_inline coh_cmd_t cmd_for_probe_downgrade()   const { return {-1, probe_msg,   downgrade_act  }; }
   __always_inline coh_cmd_t cmd_for_probe_writeback(int32_t id)   const { return {id, probe_msg,   writeback_act  }; }
   __always_inline coh_cmd_t cmd_for_probe_release(int32_t id)     const { return {id, probe_msg,   evict_act      }; }
   __always_inline coh_cmd_t cmd_for_probe_downgrade(int32_t id)   const { return {id, probe_msg,   downgrade_act  }; }
   __always_inline coh_cmd_t cmd_for_finish(int32_t id)            const { return {id, finish_msg,  0              }; }
 
   virtual coh_cmd_t cmd_for_outer_acquire(coh_cmd_t cmd) const = 0;
-
-  __always_inline coh_cmd_t cmd_for_outer_writeback(coh_cmd_t cmd) const { return outer->cmd_for_release_writeback(); }
 
   // acquire
   virtual std::pair<bool, coh_cmd_t> access_need_sync(coh_cmd_t cmd, const CMMetadataBase *meta) const = 0;
@@ -110,7 +106,7 @@ public:
   }
 
   bool probe_need_writeback(coh_cmd_t outer_cmd, CMMetadataBase *meta){
-    assert(outer->is_probe(outer_cmd));
+    assert(is_probe(outer_cmd));
     return meta->is_dirty();
   }
 
@@ -124,7 +120,7 @@ public:
         }
         meta_outer->to_dirty();
       }
-      if(outer->is_evict(outer_cmd) || !meta) meta_outer->sync(inner_id);
+      if(is_evict(outer_cmd) || !meta) meta_outer->sync(inner_id);
     }
   }
 
@@ -135,7 +131,7 @@ public:
 
   std::pair<bool, coh_cmd_t> writeback_need_writeback(const CMMetadataBase *meta, bool uncached) const {
     if(meta->is_dirty())
-      return std::make_pair(true, outer->cmd_for_release());
+      return std::make_pair(true, cmd_for_release());
     else if(!uncached)
       return outer->inner_need_release();
     else

--- a/cache/coherence.hpp
+++ b/cache/coherence.hpp
@@ -103,7 +103,7 @@ template<bool EnMT>
 class OuterCohPortUncached : public OuterCohPortBase
 {
 public:
-  OuterCohPortUncached(policy_ptr policy) : OuterCohPortBase(policy) {}
+  using OuterCohPortBase::OuterCohPortBase;
 
   virtual void acquire_req(uint64_t addr, CMMetadataBase *meta, CMDataBase *data, coh_cmd_t outer_cmd, uint64_t *delay) override {
     outer_cmd.id = coh_id;
@@ -152,7 +152,7 @@ protected:
   using OuterCohPortBase::coh_id;
   using OuterCohPortBase::policy;
 public:
-  OuterCohPortT(policy_ptr policy) : OPUC(policy) {}
+  using OPUC::OPUC;
 
   virtual std::pair<bool,bool> probe_resp(uint64_t addr, CMMetadataBase *meta_outer, CMDataBase *data_outer, coh_cmd_t outer_cmd, uint64_t *delay) override {
     uint32_t ai, s, w;
@@ -192,12 +192,12 @@ public:
         if(data_outer) data_outer->copy(data);
       }
       policy->meta_after_probe(outer_cmd, meta, meta_outer, coh_id, writeback); // alway update meta
-      cache->hook_manage(addr, ai, s, w, hit, policy->is_outer_evict(outer_cmd), writeback, meta, data, delay);
+      cache->hook_manage(addr, ai, s, w, hit, policy->is_evict(outer_cmd), writeback, meta, data, delay);
       if constexpr (EnMT) { meta_outer->unlock(); meta->unlock(); cache->reset_mt_state(ai, s, XactPrio::probe); }
     } else {
       if constexpr (EnMT) meta_outer->lock();
       policy->meta_after_probe(outer_cmd, meta, meta_outer, coh_id, writeback); // alway update meta
-      cache->hook_manage(addr, ai, s, w, hit, policy->is_outer_evict(outer_cmd), writeback, meta, data, delay);
+      cache->hook_manage(addr, ai, s, w, hit, policy->is_evict(outer_cmd), writeback, meta, data, delay);
       if constexpr (EnMT) meta_outer->unlock();
     }
     return std::make_pair(hit, writeback);
@@ -217,7 +217,7 @@ template<bool EnMT>
 class InnerCohPortUncached : public InnerCohPortBase
 {
 public:
-  InnerCohPortUncached(policy_ptr policy) : InnerCohPortBase(policy) {}
+  using InnerCohPortBase::InnerCohPortBase;
 
   virtual void acquire_resp(uint64_t addr, CMDataBase *data_inner, CMMetadataBase *meta_inner, coh_cmd_t cmd, uint64_t *delay) override {
     auto [meta, data, ai, s, w, hit] = access_line(addr, cmd, XactPrio::acquire, delay);
@@ -374,7 +374,7 @@ protected:
   using InnerCohPortBase::outer;
   using InnerCohPortBase::policy;
 public:
-  InnerCohPortT(policy_ptr policy) : IPUC(policy) {}
+  using IPUC::IPUC;
 
   virtual std::pair<bool, bool> probe_req(uint64_t addr, CMMetadataBase *meta, CMDataBase *data, coh_cmd_t cmd, uint64_t *delay) override {
     bool hit = false, writeback = false;
@@ -443,7 +443,7 @@ class CoreInterface : public InnerCohPortUncached<EnMT>, public CoreInterfaceBas
   using BaseT::outer;
 
 public:
-  CoreInterface(policy_ptr policy) : InnerCohPortUncached<EnMT>(policy) {}
+  using BaseT::BaseT;
 
   virtual const CMDataBase *read(uint64_t addr, uint64_t *delay) override {
     addr = normalize(addr);

--- a/cache/metadata.hpp
+++ b/cache/metadata.hpp
@@ -23,11 +23,9 @@ public:
 class Data64B : public CMDataBase
 {
 protected:
-  uint64_t data[8];
+  uint64_t data[8] = {0};
 
 public:
-  Data64B() : data{0} {}
-
   virtual void reset() override { for(auto &d:data) d = 0; }
   virtual uint64_t read(unsigned int index) const override { return data[index]; }
   virtual void write(unsigned int index, uint64_t wdata, uint64_t wmask) override { data[index] = (data[index] & (~wmask)) | (wdata & wmask); }
@@ -133,15 +131,13 @@ class MetadataDirectoryBase : public MetadataBroadcastBase
   __always_inline void add_sharer_help(int32_t coh_id) { if(coh_id != -1) add_sharer(coh_id); }
 
 protected:
-  uint64_t sharer;
+  uint64_t sharer = 0;
   __always_inline void add_sharer(int32_t coh_id) { sharer |= (1ull << coh_id); }
   __always_inline void clean_sharer(){ sharer = 0; }
   __always_inline void delete_sharer(int32_t coh_id){ sharer &= ~(1ull << coh_id); }
   __always_inline bool is_sharer(int32_t coh_id) const { return ((1ull << coh_id) & (sharer))!= 0; }
 
 public:
-  MetadataDirectoryBase() : sharer(0) {}
-
   virtual void to_invalid()                 override { MetadataBroadcastBase::to_invalid();         clean_sharer();          }
   virtual void to_shared(int32_t coh_id)    override { MetadataBroadcastBase::to_shared(coh_id);    add_sharer_help(coh_id); }
   virtual void to_modified(int32_t coh_id)  override { MetadataBroadcastBase::to_modified(coh_id);  add_sharer_help(coh_id); }
@@ -178,15 +174,13 @@ template <int AW, int IW, int TOfst, typename MT> requires C_DERIVE<MT, CMMetada
 class MetadataMixer : public MT
 {
 protected:
-  uint64_t     tag;
+  uint64_t     tag = 0;
   constexpr static uint64_t mask = (1ull << (AW-TOfst)) - 1;
   CMMetadataBase outer_meta; // maintain a copy of metadata for hierarchical coherence support
                              // this outer metadata is responsible only to record the S/M/E/O state seen by the outer
                              // whether the block is dirty, shared by inner caches, and directory, etc. are hold by the metadata
 
 public:
-  MetadataMixer() : tag(0) {}
-
   virtual CMMetadataBase * get_outer_meta() override { return &outer_meta; }
   virtual const CMMetadataBase * get_outer_meta() const override { return &outer_meta; }
 
@@ -229,9 +223,8 @@ template<typename MT> requires C_DERIVE<MT, CMMetadataBase>
 class MetadataWithRelocate : public MT
 {
 protected:
-  bool relocated;
+  bool relocated = false;
 public:
-  MetadataWithRelocate() : relocated(false) {}
   __always_inline void to_relocated()   { relocated = true;  }
   __always_inline void to_unrelocated() { relocated = false; }
   __always_inline bool is_relocated()   { return relocated;  }

--- a/cache/mi.hpp
+++ b/cache/mi.hpp
@@ -28,7 +28,7 @@ protected:
 
 public:
   virtual coh_cmd_t cmd_for_outer_acquire(coh_cmd_t cmd) const override {
-    return outer->cmd_for_write();
+    return cmd_for_write();
   }
 
   virtual std::pair<bool, coh_cmd_t> access_need_sync(coh_cmd_t cmd, const CMMetadataBase *meta) const override {
@@ -41,7 +41,7 @@ public:
 
   virtual void meta_after_fetch(coh_cmd_t outer_cmd, CMMetadataBase *meta, uint64_t addr) const override {
     meta->init(addr);
-    assert(outer->is_fetch_write(outer_cmd) && meta->allow_write());
+    assert(is_fetch_write(outer_cmd) && meta->allow_write());
     meta->to_modified(-1);
   }
 
@@ -52,8 +52,8 @@ public:
 
   virtual std::pair<bool, coh_cmd_t> probe_need_sync(coh_cmd_t outer_cmd, const CMMetadataBase *meta) const override {
     if constexpr (!isL1) {
-      assert(outer->is_probe(outer_cmd));
-      if(outer->is_evict(outer_cmd) || outer->is_downgrade(outer_cmd))
+      assert(is_probe(outer_cmd));
+      if(is_evict(outer_cmd) || is_downgrade(outer_cmd))
         return std::make_pair(true, cmd_for_probe_release());
       else
         return std::make_pair(true, cmd_for_probe_writeback());
@@ -63,7 +63,7 @@ public:
   virtual void meta_after_probe(coh_cmd_t outer_cmd, CMMetadataBase *meta, CMMetadataBase* meta_outer, int32_t inner_id, bool writeback) const override {
     CohPolicyBase::meta_after_probe(outer_cmd, meta, meta_outer, inner_id, writeback);
     if(meta) {
-      if(outer->is_evict(outer_cmd) || outer->is_downgrade(outer_cmd)) meta->to_invalid();
+      if(is_evict(outer_cmd) || is_downgrade(outer_cmd)) meta->to_invalid();
     }
   }
 

--- a/cache/mirage.hpp
+++ b/cache/mirage.hpp
@@ -8,11 +8,10 @@
 class MirageDataMeta : public CMMetadataCommon
 {
 protected:
-  bool state; // false: invalid, true: valid
-  uint32_t mai, ms, mw; // data meta pointer to meta
+  bool state = false; // false: invalid, true: valid
+  uint32_t mai = 0, ms = 0, mw = 0; // data meta pointer to meta
 
 public:
-  MirageDataMeta() : state(false), mai(0), ms(0), mw(0) {}
   __always_inline void bind(uint32_t ai, uint32_t s, uint32_t w) { mai = ai; ms = s; mw = w; state = true; }
   __always_inline std::tuple<uint32_t, uint32_t, uint32_t> pointer() { return std::make_tuple(mai, ms, mw);} // return the pointer to data
   virtual void to_invalid() override { state = false; }
@@ -26,10 +25,8 @@ public:
 class MirageMetadataSupport
 {
 protected:
-  uint32_t ds, dw;
+  uint32_t ds = 0, dw = 0;
 public:
-  MirageMetadataSupport() : ds(0), dw(0) {}
-
   // special methods needed for Mirage Cache
   __always_inline void bind(uint32_t s, uint32_t w) { ds = s; dw = w; }                     // initialize meta pointer
   __always_inline std::pair<uint32_t, uint32_t> pointer() { return std::make_pair(ds, dw);} // return meta pointer to data meta


### PR DESCRIPTION
* directly initialize non-static variables
* directly using constructors of base classes
* constexpr functions