### PR TITLE
Update autoconf template files to support out-of-tree building

### DIFF
--- a/flexicas.mk.in
+++ b/flexicas.mk.in
@@ -9,5 +9,5 @@ flexicas_srcs = \
 	spike-cache.cc \
 
 flexicas_precompiled = \
-	../flexicas/libflexicas.a \
-	../flexicas/cryptopp/libcryptopp.a \
+	@top_srcdir@/flexicas/libflexicas.a \
+	@top_srcdir@/flexicas/cryptopp/libcryptopp.a \


### PR DESCRIPTION
Out-of-tree build can provide better support when integrating FlexiCAS into complex projects like `spike-sdk-spec2017`.
## flexicas.mk.in:
by replacing `..` to `@top_srcdir@`, autoconf is able to find correct path of precompiled static libraries `libflexicas.a` and `cryptopp/libcryptopp.a` , otherwise we need to mannually copy these two libs to build directory.
When building under `../flexicas/build`, the macro `@top_srcdir@` still evals to `..`. Therefore the change is harmless.
## flexicas.ac:
Empty file, but necessary for `configure.ac` under parent project, e.g. `spike-flexicas/configure.ac`