### PR TITLE
Make coherence policy implemented in static classes

### DIFF
--- a/cache/cache.hpp
+++ b/cache/cache.hpp
@@ -189,12 +189,11 @@ public:
 // MT: metadata type, DT: data type (void if not in use)
 // IDX: indexer type, RPC: replacer type
 // EnMon: whether to enable monitoring
-// EF: empty first in replacer
 // EnMT: enable multithread, MSHR: maximal number of transactions on the fly
 template<int IW, int NW, int P, typename MT, typename DT, typename IDX, typename RPC, typename DLY,
-         bool EnMon, bool EF = true, bool EnMT = false, int MSHR = 4>
+         bool EnMon, bool EnMT = false, int MSHR = 4>
   requires C_DERIVE<MT, CMMetadataBase> && C_DERIVE_OR_VOID<DT, CMDataBase> &&
-           C_DERIVE<IDX, IndexFuncBase> && C_DERIVE<RPC, ReplaceFuncBase<EF> > && C_DERIVE_OR_VOID<DLY, DelayBase> &&
+           C_DERIVE<IDX, IndexFuncBase> && C_DERIVE_OR_VOID<DLY, DelayBase> &&
            (MSHR >= 2) // 2 buffers are required even for single-thread simulation
 class CacheSkewed : public CacheBase
 {
@@ -396,7 +395,7 @@ public:
 // MT: metadata type, DT: data type (void if not in use)
 // IDX: indexer type, RPC: replacer type
 // EnMon: whether to enable monitoring
-template<int IW, int NW, typename MT, typename DT, typename IDX, typename RPC, typename DLY, bool EnMon, bool EF = true, bool EnMT = false, int MSHR = 4>
-using CacheNorm = CacheSkewed<IW, NW, 1, MT, DT, IDX, RPC, DLY, EnMon, EF, EnMT, MSHR>;
+template<int IW, int NW, typename MT, typename DT, typename IDX, typename RPC, typename DLY, bool EnMon, bool EnMT = false, int MSHR = 4>
+using CacheNorm = CacheSkewed<IW, NW, 1, MT, DT, IDX, RPC, DLY, EnMon, EnMT, MSHR>;
 
 #endif

--- a/cache/coh_policy.hpp
+++ b/cache/coh_policy.hpp
@@ -4,7 +4,8 @@
 #include <utility>
 #include <tuple>
 #include <cassert>
-#include "cache/cache.hpp"
+#include <cstdint>
+#include "cache/metadata.hpp"
 
 // generice coherence command type
 // support up to 64K coherent entities, 256 message types and 256 action types
@@ -17,87 +18,77 @@ struct coh_cmd_t {
   uint32_t act   : 8;
 };
 
-class CoherentCacheBase;
+namespace coh {
 
-// functions default on MSI
-class CohPolicyBase {
-
-protected:
-  CacheBase *cache;        // reverse pointer for the cache parent
-  CohPolicyBase *outer;    // the outer policy need for command translation
-
-  static const uint32_t acquire_msg = 1;
-  static const uint32_t release_msg = 2;
-  static const uint32_t probe_msg   = 3;
-  static const uint32_t flush_msg   = 4;
-  static const uint32_t finish_msg  = 5;
-  static const uint32_t fetch_read_act  = 0;
-  static const uint32_t fetch_write_act = 1;
-  static const uint32_t evict_act       = 2;
-  static const uint32_t writeback_act   = 3;
-  static const uint32_t downgrade_act   = 4;
-
-public:
-  friend CoherentCacheBase; // deferred assignment for cache
-
-  virtual ~CohPolicyBase() = default;
-
-  __always_inline void connect(CohPolicyBase *policy) { outer = policy ? policy : this; } // memory does not use policy and returns nullptr
+  const uint32_t acquire_msg = 1;
+  const uint32_t release_msg = 2;
+  const uint32_t probe_msg   = 3;
+  const uint32_t flush_msg   = 4;
+  const uint32_t finish_msg  = 5;
+  const uint32_t fetch_read_act  = 0;
+  const uint32_t fetch_write_act = 1;
+  const uint32_t evict_act       = 2;
+  const uint32_t writeback_act   = 3;
+  const uint32_t downgrade_act   = 4;
 
   // message type
-  constexpr __always_inline bool is_acquire(coh_cmd_t cmd) const     { return cmd.msg == acquire_msg;     }
-  constexpr __always_inline bool is_release(coh_cmd_t cmd) const     { return cmd.msg == release_msg;     }
-  constexpr __always_inline bool is_probe(coh_cmd_t cmd) const       { return cmd.msg == probe_msg;       }
-  constexpr __always_inline bool is_flush(coh_cmd_t cmd) const       { return cmd.msg == flush_msg;       }
-  constexpr __always_inline bool is_finish(coh_cmd_t cmd) const      { return cmd.msg == finish_msg;      }
+  constexpr inline bool is_acquire(coh_cmd_t cmd)        { return cmd.msg == acquire_msg;     }
+  constexpr inline bool is_release(coh_cmd_t cmd)        { return cmd.msg == release_msg;     }
+  constexpr inline bool is_probe(coh_cmd_t cmd)          { return cmd.msg == probe_msg;       }
+  constexpr inline bool is_flush(coh_cmd_t cmd)          { return cmd.msg == flush_msg;       }
+  constexpr inline bool is_finish(coh_cmd_t cmd)         { return cmd.msg == finish_msg;      }
 
   // action type
-  constexpr __always_inline bool is_fetch_read(coh_cmd_t cmd) const  { return cmd.act == fetch_read_act;  }
-  constexpr __always_inline bool is_fetch_write(coh_cmd_t cmd) const { return cmd.act == fetch_write_act; }
-  constexpr __always_inline bool is_evict(coh_cmd_t cmd) const       { return cmd.act == evict_act;       }
-  constexpr __always_inline bool is_writeback(coh_cmd_t cmd) const   { return cmd.act == writeback_act;   }
-  constexpr __always_inline bool is_downgrade(coh_cmd_t cmd) const   { return cmd.act == downgrade_act;   }
-  constexpr __always_inline bool is_write(coh_cmd_t cmd) const       { return cmd.act == fetch_write_act || cmd.act == evict_act || cmd.act == writeback_act; }
+  constexpr inline bool is_fetch_read(coh_cmd_t cmd)     { return cmd.act == fetch_read_act;  }
+  constexpr inline bool is_fetch_write(coh_cmd_t cmd)    { return cmd.act == fetch_write_act; }
+  constexpr inline bool is_evict(coh_cmd_t cmd)          { return cmd.act == evict_act;       }
+  constexpr inline bool is_writeback(coh_cmd_t cmd)      { return cmd.act == writeback_act;   }
+  constexpr inline bool is_downgrade(coh_cmd_t cmd)      { return cmd.act == downgrade_act;   }
+  constexpr inline bool is_write(coh_cmd_t cmd)          { return cmd.act == fetch_write_act || cmd.act == evict_act || cmd.act == writeback_act; }
 
   // generate command
-  constexpr __always_inline coh_cmd_t cmd_for_read()              const { return {-1, acquire_msg, fetch_read_act }; }
-  constexpr __always_inline coh_cmd_t cmd_for_write()             const { return {-1, acquire_msg, fetch_write_act}; }
-  constexpr __always_inline coh_cmd_t cmd_for_flush()             const { return {-1, flush_msg,   evict_act      }; }
-  constexpr __always_inline coh_cmd_t cmd_for_writeback()         const { return {-1, flush_msg,   writeback_act  }; }
-  constexpr __always_inline coh_cmd_t cmd_for_release()           const { return {-1, release_msg, evict_act      }; }
-  constexpr __always_inline coh_cmd_t cmd_for_release_writeback() const { return {-1, release_msg, writeback_act  }; }
-  constexpr __always_inline coh_cmd_t cmd_for_null()              const { return {-1, 0,           0              }; }
-  constexpr __always_inline coh_cmd_t cmd_for_probe_writeback()   const { return {-1, probe_msg,   writeback_act  }; }
-  constexpr __always_inline coh_cmd_t cmd_for_probe_release()     const { return {-1, probe_msg,   evict_act      }; }
-  constexpr __always_inline coh_cmd_t cmd_for_probe_downgrade()   const { return {-1, probe_msg,   downgrade_act  }; }
-  __always_inline coh_cmd_t cmd_for_probe_writeback(int32_t id)   const { return {id, probe_msg,   writeback_act  }; }
-  __always_inline coh_cmd_t cmd_for_probe_release(int32_t id)     const { return {id, probe_msg,   evict_act      }; }
-  __always_inline coh_cmd_t cmd_for_probe_downgrade(int32_t id)   const { return {id, probe_msg,   downgrade_act  }; }
-  __always_inline coh_cmd_t cmd_for_finish(int32_t id)            const { return {id, finish_msg,  0              }; }
+  constexpr inline coh_cmd_t cmd_for_read()              { return {-1, acquire_msg, fetch_read_act }; }
+  constexpr inline coh_cmd_t cmd_for_write()             { return {-1, acquire_msg, fetch_write_act}; }
+  constexpr inline coh_cmd_t cmd_for_flush()             { return {-1, flush_msg,   evict_act      }; }
+  constexpr inline coh_cmd_t cmd_for_writeback()         { return {-1, flush_msg,   writeback_act  }; }
+  constexpr inline coh_cmd_t cmd_for_release()           { return {-1, release_msg, evict_act      }; }
+  constexpr inline coh_cmd_t cmd_for_release_writeback() { return {-1, release_msg, writeback_act  }; }
+  constexpr inline coh_cmd_t cmd_for_null()              { return {-1, 0,           0              }; }
+  constexpr inline coh_cmd_t cmd_for_probe_writeback()   { return {-1, probe_msg,   writeback_act  }; }
+  constexpr inline coh_cmd_t cmd_for_probe_release()     { return {-1, probe_msg,   evict_act      }; }
+  constexpr inline coh_cmd_t cmd_for_probe_downgrade()   { return {-1, probe_msg,   downgrade_act  }; }
+  inline coh_cmd_t cmd_for_probe_writeback(int32_t id)   { return {id, probe_msg,   writeback_act  }; }
+  inline coh_cmd_t cmd_for_probe_release(int32_t id)     { return {id, probe_msg,   evict_act      }; }
+  inline coh_cmd_t cmd_for_probe_downgrade(int32_t id)   { return {id, probe_msg,   downgrade_act  }; }
+  inline coh_cmd_t cmd_for_finish(int32_t id)            { return {id, finish_msg,  0              }; }
+}
 
-  virtual coh_cmd_t cmd_for_outer_acquire(coh_cmd_t cmd) const = 0;
+class CacheBase;
 
+// functions default on MI
+struct CohPolicyBase {
+  // static __always_inline coh_cmd_t cmd_for_outer_acquire(coh_cmd_t cmd);
   // acquire
-  virtual std::pair<bool, coh_cmd_t> access_need_sync(coh_cmd_t cmd, const CMMetadataBase *meta) const = 0;
-  virtual std::tuple<bool, bool, coh_cmd_t> access_need_promote(coh_cmd_t cmd, const CMMetadataBase *meta) const = 0;
+  // static __always_inline std::pair<bool, coh_cmd_t> access_need_sync(coh_cmd_t cmd, const CMMetadataBase *meta);
+  // static __always_inline std::tuple<bool, bool, coh_cmd_t> access_need_promote(coh_cmd_t cmd, const CMMetadataBase *meta);
 
   // update meta after fetching from outer cache
-  virtual void meta_after_fetch(coh_cmd_t outer_cmd, CMMetadataBase *meta, uint64_t addr) const = 0;
+  // static __always_inline void meta_after_fetch(coh_cmd_t outer_cmd, CMMetadataBase *meta, uint64_t addr);
 
   // update meta after grant to inner
-  virtual void meta_after_grant(coh_cmd_t cmd, CMMetadataBase *meta, CMMetadataBase *meta_inner) const = 0;
+  // static __always_inline void meta_after_grant(coh_cmd_t cmd, CMMetadataBase *meta, CMMetadataBase *meta_inner);
 
   // probe
-  virtual std::pair<bool, coh_cmd_t> probe_need_sync(coh_cmd_t outer_cmd, const CMMetadataBase *meta) const = 0;
+  // static __always_inline std::pair<bool, coh_cmd_t> probe_need_sync(coh_cmd_t outer_cmd, const CMMetadataBase *meta);
 
-  std::pair<bool, coh_cmd_t> probe_need_probe(coh_cmd_t cmd, const CMMetadataBase *meta, int32_t target_inner_id) const {
-    assert(is_probe(cmd));
+  static __always_inline std::pair<bool, coh_cmd_t> probe_need_probe(coh_cmd_t cmd, const CMMetadataBase *meta, int32_t target_inner_id) {
+    assert(coh::is_probe(cmd));
     if(meta) {
-      if((is_evict(cmd) && meta->evict_need_probe(target_inner_id, cmd.id)) || meta->writeback_need_probe(target_inner_id, cmd.id) ) {
+      if((coh::is_evict(cmd) && meta->evict_need_probe(target_inner_id, cmd.id)) || meta->writeback_need_probe(target_inner_id, cmd.id) ) {
         cmd.id = -1;
         return std::make_pair(true, cmd);
       } else
-        return std::make_pair(false, cmd_for_null());
+        return std::make_pair(false, coh::cmd_for_null());
     }
     else{
       cmd.id = -1;
@@ -105,12 +96,12 @@ public:
     }
   }
 
-  bool probe_need_writeback(coh_cmd_t outer_cmd, CMMetadataBase *meta){
-    assert(is_probe(outer_cmd));
+  static __always_inline bool probe_need_writeback(coh_cmd_t outer_cmd, CMMetadataBase *meta) {
+    assert(coh::is_probe(outer_cmd));
     return meta->is_dirty();
   }
 
-  virtual void meta_after_probe(coh_cmd_t outer_cmd, CMMetadataBase *meta, CMMetadataBase* meta_outer, int32_t inner_id, bool writeback) const {
+  static __always_inline void meta_after_probe(coh_cmd_t outer_cmd, CMMetadataBase *meta, CMMetadataBase* meta_outer, int32_t inner_id, bool writeback) {
     if(meta_outer) { // clean sharer if evict or miss
       if(writeback) {
         if(!meta_outer->is_valid()) {
@@ -120,54 +111,47 @@ public:
         }
         meta_outer->to_dirty();
       }
-      if(is_evict(outer_cmd) || !meta) meta_outer->sync(inner_id);
+      if(coh::is_evict(outer_cmd) || !meta) meta_outer->sync(inner_id);
     }
   }
 
   // writeback due to conflict, probe, flush
-  virtual std::pair<bool, coh_cmd_t> writeback_need_sync(const CMMetadataBase *meta) const {
-    return std::make_pair(true, cmd_for_probe_release());
+  static __always_inline std::pair<bool, coh_cmd_t> writeback_need_sync(const CMMetadataBase *meta) {
+    return std::make_pair(true, coh::cmd_for_probe_release());
   }
 
-  std::pair<bool, coh_cmd_t> writeback_need_writeback(const CMMetadataBase *meta, bool uncached) const {
-    if(meta->is_dirty())
-      return std::make_pair(true, cmd_for_release());
-    else if(!uncached)
-      return outer->inner_need_release();
-    else
-      return std::make_pair(false, cmd_for_null());
-  }
+  // static __always_inline std::pair<bool, coh_cmd_t> writeback_need_writeback(const CMMetadataBase *meta, bool uncached, CohPolicyBase *outer);
 
-  void meta_after_writeback(coh_cmd_t outer_cmd, CMMetadataBase *meta) const {
+  static __always_inline void meta_after_writeback(coh_cmd_t outer_cmd, CMMetadataBase *meta) {
     if(meta) meta->to_clean(); // flush may send out writeback request with null meta
   }
 
-  void meta_after_evict(CMMetadataBase *meta) const{
+  static __always_inline void meta_after_evict(CMMetadataBase *meta) {
     assert(!meta->is_dirty());
     meta->to_invalid();
   }
 
   // release from inner
-  virtual std::pair<bool, coh_cmd_t> release_need_sync(coh_cmd_t cmd, const CMMetadataBase *meta, const CMMetadataBase* meta_inner) const {
-    return std::make_pair(false, cmd_for_null());
+  static __always_inline std::pair<bool, coh_cmd_t> release_need_sync(coh_cmd_t cmd, const CMMetadataBase *meta, const CMMetadataBase* meta_inner) {
+    return std::make_pair(false, coh::cmd_for_null());
   }
   
-  virtual void meta_after_release(coh_cmd_t cmd, CMMetadataBase *meta, CMMetadataBase* meta_inner) const {
+  static __always_inline void meta_after_release(coh_cmd_t cmd, CMMetadataBase *meta, CMMetadataBase* meta_inner) {
     meta->to_dirty();
-    if(meta_inner && is_evict(cmd))
+    if(meta_inner && coh::is_evict(cmd))
       meta_inner->to_invalid();
   }
 
   // flush
-  virtual std::tuple<bool, bool, coh_cmd_t> flush_need_sync(coh_cmd_t cmd, const CMMetadataBase *meta, bool uncached) const = 0;
+  // static __always_inline std::tuple<bool, bool, coh_cmd_t> flush_need_sync(coh_cmd_t cmd, const CMMetadataBase *meta, bool uncached);
 
-  void meta_after_flush(coh_cmd_t cmd, CMMetadataBase *meta) const  {
-    if(meta && is_evict(cmd)) meta->to_invalid();
+  static __always_inline void meta_after_flush(coh_cmd_t cmd, CMMetadataBase *meta, CacheBase *) {
+    if(meta && coh::is_evict(cmd)) meta->to_invalid();
   }
 
-  virtual std::pair<bool, coh_cmd_t> inner_need_release(){
+  static __always_inline std::pair<bool, coh_cmd_t> inner_need_release() {
     // here we suppose inner meta is clean and inner cache is asking outer cache if it need to be released
-    return std::make_pair(false, cmd_for_null());
+    return std::make_pair(false, coh::cmd_for_null());
   }
 
 };

--- a/cache/coherence.hpp
+++ b/cache/coherence.hpp
@@ -1,8 +1,8 @@
 #ifndef CM_CACHE_COHERENCE_HPP
 #define CM_CACHE_COHERENCE_HPP
 
-#include "cache/cache.hpp"
 #include "cache/coh_policy.hpp"
+#include "cache/cache.hpp"
 #include "cache/slicehash.hpp"
 #include <tuple>
 #include <memory>
@@ -28,8 +28,6 @@ class CoherentCacheBase;
 typedef OuterCohPortBase CohClientBase;
 typedef InnerCohPortBase CohMasterBase;
 
-typedef std::shared_ptr<CohPolicyBase> policy_ptr;
-
 /////////////////////////////////
 // Base interface for outer ports
 
@@ -40,13 +38,11 @@ protected:
   InnerCohPortBase *inner; // inner port for probe when sync
   CohMasterBase *coh;      // hook up with the coherence hub
   int32_t coh_id;          // the identifier used in locating this cache client by the coherence master
-  policy_ptr policy;       // the coherence policy
 
 public:
-  OuterCohPortBase(policy_ptr policy) : policy(policy) {}
   virtual ~OuterCohPortBase() = default;
 
-  void connect(CohMasterBase *h, std::pair<int32_t, policy_ptr> info) { coh = h; coh_id = info.first; policy->connect(info.second.get()); }
+  void connect(CohMasterBase *h, int32_t id) { coh = h; coh_id = id; }
 
   virtual void acquire_req(uint64_t addr, CMMetadataBase *meta, CMDataBase *data, coh_cmd_t cmd, uint64_t *delay) = 0;
   virtual void writeback_req(uint64_t addr, CMMetadataBase *meta, CMDataBase *data, coh_cmd_t cmd, uint64_t *delay) = 0;
@@ -69,19 +65,17 @@ protected:
   CacheBase *cache; // reverse pointer for the cache parent
   OuterCohPortBase *outer; // outer port for writeback when replace
   std::vector<CohClientBase *> coh; // hook up with the inner caches, indexed by vector index
-  policy_ptr policy; // the coherence policy
 public:
-  InnerCohPortBase(policy_ptr policy) : policy(policy) {}
   virtual ~InnerCohPortBase() = default;
 
-  virtual std::pair<uint32_t, policy_ptr> connect(CohClientBase *c, bool uncached = false) {
+  virtual uint32_t connect(CohClientBase *c, bool uncached = false) {
     if(uncached) {
-      return std::make_pair(-1, policy);
+      return -1;
     } else {
       coh.push_back(c);
       assert(coh.size() <= 63 || 0 ==
              "Only 63 coherent inner caches are supported for now as the directory in class MetadataDirectoryBase is implemented as a 64-bit bitmap.");
-      return std::make_pair(coh.size()-1, policy);
+      return coh.size()-1;
     }
   }
 
@@ -99,12 +93,10 @@ public:
 };
 
 // common behvior for uncached outer ports
-template<bool EnMT>
+template<class Policy, bool EnMT> requires C_DERIVE<Policy, CohPolicyBase>
 class OuterCohPortUncached : public OuterCohPortBase
 {
 public:
-  using OuterCohPortBase::OuterCohPortBase;
-
   virtual void acquire_req(uint64_t addr, CMMetadataBase *meta, CMDataBase *data, coh_cmd_t outer_cmd, uint64_t *delay) override {
     outer_cmd.id = coh_id;
 
@@ -128,14 +120,14 @@ public:
       cache->meta_return_buffer(mmeta); cache->data_return_buffer(mdata);
     }
 
-    policy->meta_after_fetch(outer_cmd, meta, addr);
+    Policy::meta_after_fetch(outer_cmd, meta, addr);
   }
 
   virtual void writeback_req(uint64_t addr, CMMetadataBase *meta, CMDataBase *data, coh_cmd_t outer_cmd, uint64_t *delay) override {
     outer_cmd.id = coh_id;
     CMMetadataBase *outer_meta = meta ? meta->get_outer_meta() : nullptr;
     coh->writeback_resp(addr, data, outer_meta, outer_cmd, delay);
-    policy->meta_after_writeback(outer_cmd, meta);
+    Policy::meta_after_writeback(outer_cmd, meta);
   }
 
   virtual void query_loc_req(uint64_t addr, std::list<LocInfo> *locs) override {
@@ -144,16 +136,13 @@ public:
 };
 
 // common behavior for cached outer ports
-template<class OPUC, bool EnMT> requires C_DERIVE<OPUC, OuterCohPortUncached<EnMT> >
-class OuterCohPortT : public OPUC
+template<template <typename, bool, typename...> class OPUC, typename Policy, bool EnMT, typename... Extra> requires C_DERIVE<OPUC<Policy, EnMT>, OuterCohPortBase>
+class OuterCohPortT : public OPUC<Policy, EnMT, Extra...>
 {
 protected:
   using OuterCohPortBase::cache;
   using OuterCohPortBase::coh_id;
-  using OuterCohPortBase::policy;
 public:
-  using OPUC::OPUC;
-
   virtual std::pair<bool,bool> probe_resp(uint64_t addr, CMMetadataBase *meta_outer, CMDataBase *data_outer, coh_cmd_t outer_cmd, uint64_t *delay) override {
     uint32_t ai, s, w;
     bool writeback = false;
@@ -181,23 +170,23 @@ public:
     if(hit) {
       if constexpr (EnMT) meta_outer->lock();
       // sync if necessary
-      auto sync = policy->probe_need_sync(outer_cmd, meta);
+      auto sync = Policy::probe_need_sync(outer_cmd, meta);
       if(sync.first) {
         auto [phit, pwb] = OuterCohPortBase::inner->probe_req(addr, meta, data, sync.second, delay);
         if(pwb) cache->hook_write(addr, ai, s, w, true, false, meta, data, delay);
       }
 
       // writeback if dirty
-      if((writeback = policy->probe_need_writeback(outer_cmd, meta))) {
+      if((writeback = Policy::probe_need_writeback(outer_cmd, meta))) {
         if(data_outer) data_outer->copy(data);
       }
-      policy->meta_after_probe(outer_cmd, meta, meta_outer, coh_id, writeback); // alway update meta
-      cache->hook_manage(addr, ai, s, w, hit, policy->is_evict(outer_cmd), writeback, meta, data, delay);
+      Policy::meta_after_probe(outer_cmd, meta, meta_outer, coh_id, writeback); // alway update meta
+      cache->hook_manage(addr, ai, s, w, hit, coh::is_evict(outer_cmd), writeback, meta, data, delay);
       if constexpr (EnMT) { meta_outer->unlock(); meta->unlock(); cache->reset_mt_state(ai, s, XactPrio::probe); }
     } else {
       if constexpr (EnMT) meta_outer->lock();
-      policy->meta_after_probe(outer_cmd, meta, meta_outer, coh_id, writeback); // alway update meta
-      cache->hook_manage(addr, ai, s, w, hit, policy->is_evict(outer_cmd), writeback, meta, data, delay);
+      Policy::meta_after_probe(outer_cmd, meta, meta_outer, coh_id, writeback); // alway update meta
+      cache->hook_manage(addr, ai, s, w, hit, coh::is_evict(outer_cmd), writeback, meta, data, delay);
       if constexpr (EnMT) meta_outer->unlock();
     }
     return std::make_pair(hit, writeback);
@@ -205,32 +194,30 @@ public:
 
   virtual void finish_req(uint64_t addr) override {
     assert(!this->is_uncached());
-    OuterCohPortBase::coh->finish_resp(addr, policy->cmd_for_finish(coh_id));
+    OuterCohPortBase::coh->finish_resp(addr, coh::cmd_for_finish(coh_id));
   }
 
 };
 
-template <bool EnMT = false>
-using OuterCohPort = OuterCohPortT<OuterCohPortUncached<EnMT>, EnMT> ;
+template<typename Policy, bool EnMT = false>
+using OuterCohPort = OuterCohPortT<OuterCohPortUncached, Policy, EnMT>;
 
-template<bool EnMT>
+template<typename Policy, bool EnMT> requires C_DERIVE<Policy, CohPolicyBase>
 class InnerCohPortUncached : public InnerCohPortBase
 {
 public:
-  using InnerCohPortBase::InnerCohPortBase;
-
   virtual void acquire_resp(uint64_t addr, CMDataBase *data_inner, CMMetadataBase *meta_inner, coh_cmd_t cmd, uint64_t *delay) override {
     auto [meta, data, ai, s, w, hit] = access_line(addr, cmd, XactPrio::acquire, delay);
 
     if (data_inner && data) data_inner->copy(data);
-    policy->meta_after_grant(cmd, meta, meta_inner);
+    Policy::meta_after_grant(cmd, meta, meta_inner);
     cache->hook_read(addr, ai, s, w, hit, meta, data, delay);
-    finish_record(addr, policy->cmd_for_finish(cmd.id), !hit, meta, ai, s);
-    if(cmd.id == -1) finish_resp(addr, policy->cmd_for_finish(cmd.id));
+    finish_record(addr, coh::cmd_for_finish(cmd.id), !hit, meta, ai, s);
+    if(cmd.id == -1) finish_resp(addr, coh::cmd_for_finish(cmd.id));
   }
 
   virtual void writeback_resp(uint64_t addr, CMDataBase *data_inner, CMMetadataBase *meta_inner, coh_cmd_t cmd, uint64_t *delay) override {
-    if(policy->is_flush(cmd))
+    if(coh::is_flush(cmd))
       flush_line(addr, cmd, delay);
     else
       write_line(addr, data_inner, meta_inner, cmd, delay);
@@ -246,14 +233,14 @@ protected:
     // evict a block due to conflict
     auto addr = meta->addr(s);
     assert(cache->hit(addr));
-    auto sync = policy->writeback_need_sync(meta);
+    auto sync = Policy::writeback_need_sync(meta);
     if(sync.first) {
       auto [phit, pwb] = probe_req(addr, meta, data, sync.second, delay); // sync if necessary
       if(pwb) cache->hook_write(addr, ai, s, w, true, false, meta, data, delay); // a write occurred during the probe
     }
-    auto writeback = policy->writeback_need_writeback(meta, outer->is_uncached());
+    auto writeback = Policy::writeback_need_writeback(meta, outer->is_uncached());
     if(writeback.first) outer->writeback_req(addr, meta, data, writeback.second, delay); // writeback if dirty
-    policy->meta_after_evict(meta);
+    Policy::meta_after_evict(meta);
     cache->hook_manage(addr, ai, s, w, true, true, writeback.first, meta, data, delay);
   }
 
@@ -290,17 +277,17 @@ protected:
     }
 
     if(hit) {
-      auto sync = policy->access_need_sync(cmd, meta);
+      auto sync = Policy::access_need_sync(cmd, meta);
       if(sync.first) {
         auto [phit, pwb] = probe_req(addr, meta, data, sync.second, delay); // sync if necessary
         if(pwb) cache->hook_write(addr, ai, s, w, true, false, meta, data, delay); // a write occurred during the probe
       }
-      auto [promote, promote_local, promote_cmd] = policy->access_need_promote(cmd, meta);
+      auto [promote, promote_local, promote_cmd] = Policy::access_need_promote(cmd, meta);
       if(promote) { outer->acquire_req(addr, meta, data, promote_cmd, delay); hit = false; } // promote permission if needed
       else if(promote_local) meta->to_modified(-1);
     } else { // miss
       if(meta->is_valid()) evict(meta, data, ai, s, w, delay);
-      outer->acquire_req(addr, meta, data, policy->cmd_for_outer_acquire(cmd), delay); // fetch the missing block
+      outer->acquire_req(addr, meta, data, Policy::cmd_for_outer_acquire(cmd), delay); // fetch the missing block
     }
     return std::make_tuple(meta, data, ai, s, w, hit);
   }
@@ -309,7 +296,7 @@ protected:
     auto [meta, data, ai, s, w, hit] = access_line(addr, cmd, XactPrio::release, delay);
     assert(hit || cmd.id == -1); // must hit if the inner is cached
     if(data_inner) data->copy(data_inner);
-    policy->meta_after_release(cmd, meta, meta_inner);
+    Policy::meta_after_release(cmd, meta, meta_inner);
     assert(meta_inner); // assume meta_inner is valid for all writebacks
     cache->hook_write(addr, ai, s, w, hit, false, meta, data, delay);
     if constexpr (EnMT) { meta->unlock(); cache->reset_mt_state(ai, s, XactPrio::release); }
@@ -338,10 +325,10 @@ protected:
       if(hit) std::tie(meta, data) = cache->access_line(ai, s, w);
     }
 
-    auto [flush, probe, probe_cmd] = policy->flush_need_sync(cmd, meta, outer->is_uncached());
+    auto [flush, probe, probe_cmd] = Policy::flush_need_sync(cmd, meta, outer->is_uncached());
     if(!flush) {
       // do not handle flush at this level, and send it to the outer cache
-      outer->writeback_req(addr, nullptr, nullptr, policy->cmd_for_flush(), delay);
+      outer->writeback_req(addr, nullptr, nullptr, coh::cmd_for_flush(), delay);
       return;
     }
 
@@ -352,19 +339,19 @@ protected:
       if(pwb) cache->hook_write(addr, ai, s, w, true, false, meta, data, delay); // a write occurred during the probe
     }
 
-    auto writeback = policy->writeback_need_writeback(meta, outer->is_uncached());
+    auto writeback = Policy::writeback_need_writeback(meta, outer->is_uncached());
     if(writeback.first) outer->writeback_req(addr, meta, data, writeback.second, delay); // writeback if dirty
 
-    policy->meta_after_flush(cmd, meta);
-    cache->hook_manage(addr, ai, s, w, hit, policy->is_evict(cmd), writeback.first, meta, data, delay);
+    Policy::meta_after_flush(cmd, meta, cache);
+    cache->hook_manage(addr, ai, s, w, hit, coh::is_evict(cmd), writeback.first, meta, data, delay);
 
     if constexpr (EnMT) { meta->unlock(); cache->reset_mt_state(ai, s, XactPrio::flush); }
   }
 
 };
 
-template<class IPUC, bool EnMT> requires C_DERIVE<IPUC, InnerCohPortUncached<EnMT> >
-class InnerCohPortT : public IPUC
+template<template <typename, bool, typename...> class IPUC, typename Policy, bool EnMT, typename... Extra> requires C_DERIVE<IPUC<Policy, EnMT, Extra...>, InnerCohPortBase>
+class InnerCohPortT : public IPUC<Policy, EnMT, Extra...>
 {
 private:
   PendingXact<EnMT> pending_xact; // record the pending finish message from inner caches
@@ -372,15 +359,12 @@ protected:
   using InnerCohPortBase::cache;
   using InnerCohPortBase::coh;
   using InnerCohPortBase::outer;
-  using InnerCohPortBase::policy;
 public:
-  using IPUC::IPUC;
-
   virtual std::pair<bool, bool> probe_req(uint64_t addr, CMMetadataBase *meta, CMDataBase *data, coh_cmd_t cmd, uint64_t *delay) override {
     bool hit = false, writeback = false;
     if constexpr (EnMT) meta->unlock();
     for(uint32_t i=0; i<coh.size(); i++) {
-      auto probe = policy->probe_need_probe(cmd, meta, i);
+      auto probe = Policy::probe_need_probe(cmd, meta, i);
       if(probe.first) {
         auto [phit, pwb] = coh[i]->probe_resp(addr, meta, data, probe.second, delay);
         hit       |= phit;
@@ -409,8 +393,8 @@ public:
   }
 };
 
-template<bool EnMT = false>
-using InnerCohPort = InnerCohPortT<InnerCohPortUncached<EnMT>, EnMT>;
+template<typename Policy, bool EnMT = false>
+using InnerCohPort = InnerCohPortT<InnerCohPortUncached, Policy, EnMT>;
 
 // base class for CoreInterface
 class CoreInterfaceBase
@@ -435,10 +419,9 @@ public:
 };
 
 // interface with the processing core is a special InnerCohPort
-template<bool EnMT = false>
-class CoreInterface : public InnerCohPortUncached<EnMT>, public CoreInterfaceBase {
-  typedef InnerCohPortUncached<EnMT> BaseT;
-  using BaseT::policy;
+template<typename Policy, bool EnMT = false>
+class CoreInterface : public InnerCohPortUncached<Policy, EnMT>, public CoreInterfaceBase {
+  typedef InnerCohPortUncached<Policy, EnMT> BaseT;
   using BaseT::cache;
   using BaseT::outer;
 
@@ -447,7 +430,7 @@ public:
 
   virtual const CMDataBase *read(uint64_t addr, uint64_t *delay) override {
     addr = normalize(addr);
-    auto cmd = policy->cmd_for_read();
+    auto cmd = coh::cmd_for_read();
     auto [meta, data, ai, s, w, hit] = this->access_line(addr, cmd, XactPrio::acquire, delay);
     cache->hook_read(addr, ai, s, w, hit, meta, data, delay);
     if constexpr (EnMT) { meta->unlock(); cache->reset_mt_state(ai, s, XactPrio::acquire);}
@@ -460,7 +443,7 @@ public:
 
   virtual void write(uint64_t addr, const CMDataBase *m_data, uint64_t *delay) override {
     addr = normalize(addr);
-    auto cmd = policy->cmd_for_write();
+    auto cmd = coh::cmd_for_write();
     auto [meta, data, ai, s, w, hit] = this->access_line(addr, cmd, XactPrio::acquire, delay);
     meta->to_dirty();
     if(data) data->copy(m_data);
@@ -472,8 +455,8 @@ public:
 #endif
   }
 
-  virtual void flush(uint64_t addr, uint64_t *delay) override     { addr = normalize(addr); this->flush_line(addr, policy->cmd_for_flush(), delay); }
-  virtual void writeback(uint64_t addr, uint64_t *delay) override { addr = normalize(addr); this->flush_line(addr, policy->cmd_for_writeback(), delay); }
+  virtual void flush(uint64_t addr, uint64_t *delay) override     { addr = normalize(addr); this->flush_line(addr, coh::cmd_for_flush(), delay); }
+  virtual void writeback(uint64_t addr, uint64_t *delay) override { addr = normalize(addr); this->flush_line(addr, coh::cmd_for_writeback(), delay); }
   virtual void writeback_invalidate(uint64_t *delay) override     { assert(nullptr == "Error: L1.writeback_invalidate() is not implemented yet!"); }
 
   virtual void flush_cache(uint64_t *delay) override {
@@ -486,7 +469,7 @@ public:
           if(meta->is_valid()) {
             auto addr = meta->addr(iset);
             if constexpr (EnMT) meta->unlock();
-            this->flush_line(addr, policy->cmd_for_flush(), delay);
+            this->flush_line(addr, coh::cmd_for_flush(), delay);
           } else {
             if constexpr (EnMT) meta->unlock();
           }
@@ -501,7 +484,7 @@ public:
 
 private:
   // hide and prohibit calling these functions
-  virtual std::pair<uint32_t, policy_ptr> connect(CohClientBase *, bool) override { return std::make_pair(-1, policy); }
+  virtual uint32_t connect(CohClientBase *, bool) override { return -1; }
   virtual void acquire_resp(uint64_t, CMDataBase *, CMMetadataBase *, coh_cmd_t, uint64_t *) override {}
   virtual void writeback_resp(uint64_t, CMDataBase *, CMMetadataBase *, coh_cmd_t, uint64_t *) override {}
 };
@@ -520,13 +503,12 @@ public:
   OuterCohPortBase *outer; // coherence outer port, nullptr if last level
   InnerCohPortBase *inner; // coherence inner port, always has inner
 
-  CoherentCacheBase(CacheBase *cache, OuterCohPortBase *outer, InnerCohPortBase *inner, policy_ptr policy, std::string name)
+  CoherentCacheBase(CacheBase *cache, OuterCohPortBase *outer, InnerCohPortBase *inner, std::string name)
     : name(name), cache(cache), outer(outer), inner(inner)
   {
     // deferred assignment for the reverse pointer to cache
-    outer->cache = cache; outer->inner = inner; outer->policy = policy;
-    inner->cache = cache; inner->outer = outer; inner->policy = policy;
-    policy->cache = cache;
+    outer->cache = cache; outer->inner = inner;
+    inner->cache = cache; inner->outer = outer;
   }
 
   virtual ~CoherentCacheBase() {
@@ -548,8 +530,8 @@ template<typename CacheT, typename OuterT, class InnerT>
 class CoherentCacheNorm : public CoherentCacheBase
 {
 public:
-  CoherentCacheNorm(policy_ptr policy, std::string name = "")
-    : CoherentCacheBase(new CacheT(name), new OuterT(policy), new InnerT(policy), policy, name) {}
+  CoherentCacheNorm(std::string name = "")
+    : CoherentCacheBase(new CacheT(name), new OuterT, new InnerT, name) {}
 };
 
 /////////////////////////////////
@@ -565,7 +547,7 @@ protected:
   std::vector<CohMasterBase*> cohm;
   HT hasher;
 public:
-  SliceDispatcher(const std::string &n, int slice) : CohMasterBase(nullptr), name(n), hasher(slice) {}
+  SliceDispatcher(const std::string &n, int slice) : name(n), hasher(slice) {}
   void connect(CohMasterBase *c) { cohm.push_back(c); }
   virtual void acquire_resp(uint64_t addr, CMDataBase *data_inner, CMMetadataBase *meta_inner, coh_cmd_t cmd, uint64_t *delay) override {
     cohm[hasher(addr)]->acquire_resp(addr, data_inner, meta_inner, cmd, delay);

--- a/cache/memory.hpp
+++ b/cache/memory.hpp
@@ -1,18 +1,18 @@
 #ifndef CM_CACHE_MEMORY_HPP
 #define CM_CACHE_MEMORY_HPP
 
-#include "cache/coherence.hpp"
 #include "cache/mi.hpp"
+#include "cache/coherence.hpp"
 #include <sys/mman.h>
 #include <unordered_map>
 #include <shared_mutex>
 
+typedef MIPolicy<false,false,CohPolicyBase> policy_memory;
+
 template<typename DT, typename DLY, bool EnMon = false, bool EnMT = false>
   requires C_DERIVE_OR_VOID<DT, CMDataBase> && C_DERIVE_OR_VOID<DLY, DelayBase>
-  class SimpleMemoryModel : public InnerCohPortUncached<EnMT>, public CacheMonitorSupport
+class SimpleMemoryModel : public InnerCohPortUncached<policy_memory, EnMT>, public CacheMonitorSupport
 {
-  using InnerCohPortBase::policy;
-
 #ifdef CHECK_MULTI
   std::unordered_set<uint64_t> active_addr_set;
   std::mutex                   active_addr_mutex;
@@ -68,10 +68,8 @@ protected:
   }
 
 public:
-  SimpleMemoryModel(const std::string &n)
-    : InnerCohPortUncached<EnMT>(nullptr), id(UniqueID::new_id(n)), name(n)
+  SimpleMemoryModel(const std::string &n) : id(UniqueID::new_id(n)), name(n)
   {
-    policy = policy_ptr(new MIPolicy<MetadataMI,false,false>());
     monitors = new CacheMonitorImp<DLY, EnMon>(id);
   }
 

--- a/cache/mesi.hpp
+++ b/cache/mesi.hpp
@@ -14,17 +14,12 @@ class MetadataMESIBase : public BT
 template <int AW, int IW, int TOfst>
 using MetadataMESIDirectory = MetadataDirectory<AW, IW, TOfst, MetadataMESIBase<MetadataDirectoryBase> >;
 
-template<typename MT, bool isL1, bool isLLC> requires C_DERIVE<MT, MetadataDirectoryBase> && (!isL1)
-class MESIPolicy : public MSIPolicy<MT, false, isLLC>
+template<bool isL1, bool isLLC, typename Outer> requires (!isL1)
+struct MESIPolicy : public MSIPolicy<false, isLLC, Outer>
 {
-protected:
-  using CohPolicyBase::is_fetch_read;
-  using CohPolicyBase::is_fetch_write;
-
-public:
-  virtual void meta_after_grant(coh_cmd_t cmd, CMMetadataBase *meta, CMMetadataBase *meta_inner) const override {
+  static __always_inline void meta_after_grant(coh_cmd_t cmd, CMMetadataBase *meta, CMMetadataBase *meta_inner) {
     int32_t id = cmd.id;
-    if(is_fetch_read(cmd)) {
+    if(coh::is_fetch_read(cmd)) {
       meta->to_shared(id);
       if(static_cast<MetadataDirectoryBase *>(meta)->is_exclusive_sharer(id)) { // add the support for exclusive
         meta->to_exclusive(id);
@@ -32,7 +27,7 @@ public:
       } else
         meta_inner->to_shared(-1);
     } else {
-      assert(is_fetch_write(cmd));
+      assert(coh::is_fetch_write(cmd));
       meta->to_modified(id);
       meta_inner->to_modified(-1);
     }

--- a/cache/mirage.hpp
+++ b/cache/mirage.hpp
@@ -216,17 +216,13 @@ public:
 // uncached MSI inner port:
 //   no support for reverse probe as if there is no internal cache
 //   or the interl cache does not participate in the coherence communication
-template<typename MT, typename CT, bool EnMT>
-  requires C_DERIVE<MT, MetadataBroadcastBase, MirageMetadataSupport> && C_DERIVE<CT, CacheBase>
-class MirageInnerPortUncached : public InnerCohPortUncached<EnMT>
+template<typename Policy, bool EnMT, typename MT, typename CT>
+  requires C_DERIVE<MT, MetadataBroadcastBase, MirageMetadataSupport> && C_DERIVE<CT, CacheBase> && C_DERIVE<Policy, CohPolicyBase>
+class MirageInnerPortUncached : public InnerCohPortUncached<Policy, EnMT>
 {
 protected:
-  using InnerCohPortBase::policy;
   using InnerCohPortBase::outer;
-public:
-  MirageInnerPortUncached(policy_ptr policy) : InnerCohPortUncached<EnMT>(policy) {}
 
-protected:
   virtual std::tuple<CMMetadataBase *, CMDataBase *, uint32_t, uint32_t, uint32_t, bool>
   access_line(uint64_t addr, coh_cmd_t cmd, uint16_t prio, uint64_t *delay) override { // common function for access a line in the cache
     uint32_t ai, s, w;
@@ -236,12 +232,12 @@ protected:
     bool hit = cache->hit(addr, &ai, &s, &w, prio, EnMT);
     if(hit) {
       std::tie(meta, data) = cache->access_line(ai, s, w);
-      auto sync = policy->access_need_sync(cmd, meta);
+      auto sync = Policy::access_need_sync(cmd, meta);
       if(sync.first) {
         auto [phit, pwb] = this->probe_req(addr, meta, data, sync.second, delay); // sync if necessary
         if(pwb) cache->hook_write(addr, ai, s, w, true, false, meta, data, delay); // a write occurred during the probe
       }
-      auto [promote, promote_local, promote_cmd] = policy->access_need_promote(cmd, meta);
+      auto [promote, promote_local, promote_cmd] = Policy::access_need_promote(cmd, meta);
       if(promote) { outer->acquire_req(addr, meta, data, promote_cmd, delay); hit = false; } // promote permission if needed
       else if(promote_local) meta->to_modified(-1);
     } else { // miss
@@ -268,14 +264,13 @@ protected:
       static_cast<MT *>(meta)->bind(data_pointer.first, data_pointer.second);
       data_meta->bind(ai, s, w);
 
-      outer->acquire_req(addr, meta, data, policy->cmd_for_outer_acquire(cmd), delay); // fetch the missing block
+      outer->acquire_req(addr, meta, data, Policy::cmd_for_outer_acquire(cmd), delay); // fetch the missing block
     }
     return std::make_tuple(meta, data, ai, s, w, hit);
   }
 };
 
-template<typename MT, typename CT, bool EnMT>
-  requires C_DERIVE<MT, MetadataBroadcastBase, MirageMetadataSupport> && C_DERIVE<CT, CacheBase>
-using MirageInnerCohPort = InnerCohPortT<MirageInnerPortUncached<MT, CT, EnMT>, EnMT>;
+template<typename Policy, bool EnMT, typename MT, typename CT>
+using MirageInnerCohPort = InnerCohPortT<MirageInnerPortUncached, Policy, EnMT, MT, CT>;
 
 #endif

--- a/cache/mirage.hpp
+++ b/cache/mirage.hpp
@@ -75,18 +75,17 @@ public:
 // DIDX: data indexer type, DRPC: data replacer type
 // EnMon: whether to enable monitoring
 // EnableRelocation : whether to enable relocation
-// EF: empty first in replacer
 template<int IW, int NW, int EW, int P, int MaxRelocN, typename MT, typename DT,
          typename DTMT, typename MIDX, typename DIDX, typename MRPC, typename DRPC, typename DLY, bool EnMon, bool EnableRelocation,
-         bool EF = true, bool EnMT = false, int MSHR = 4>
+         bool EnMT = false, int MSHR = 4>
   requires C_DERIVE<MT, MetadataBroadcastBase, MirageMetadataSupport> && C_DERIVE_OR_VOID<DT, CMDataBase> &&
            C_DERIVE<DTMT, MirageDataMeta>  && C_DERIVE<MIDX, IndexFuncBase>   && C_DERIVE<DIDX, IndexFuncBase> &&
-           C_DERIVE<MRPC, ReplaceFuncBase<EF> > && C_DERIVE<DRPC, ReplaceFuncBase<EF> > && C_DERIVE_OR_VOID<DLY, DelayBase>
-class MirageCache : public CacheSkewed<IW, NW+EW, P, MT, void, MIDX, MRPC, DLY, EnMon, EF, EnMT, MSHR>
+           C_DERIVE_OR_VOID<DLY, DelayBase>
+class MirageCache : public CacheSkewed<IW, NW+EW, P, MT, void, MIDX, MRPC, DLY, EnMon, EnMT, MSHR>
 {
 // see: https://www.usenix.org/system/files/sec21fall-saileshwar.pdf
 
-  typedef CacheSkewed<IW, NW+EW, P, MT, void, MIDX, MRPC, DLY, EnMon, EF, EnMT, MSHR> CacheT;
+  typedef CacheSkewed<IW, NW+EW, P, MT, void, MIDX, MRPC, DLY, EnMon, EnMT, MSHR> CacheT;
 protected:
   using CacheBase::arrays;
   using CacheT::indexer;

--- a/cache/mirage.hpp
+++ b/cache/mirage.hpp
@@ -52,17 +52,14 @@ public:
 };
 
 // MirageMSI protocol
-template<typename MT, typename CT>
+template<typename MT, typename CT, typename Outer>
   requires C_DERIVE<MT, MetadataBroadcastBase, MirageMetadataSupport> && C_DERIVE<CT, CacheBase>
-class MirageMSIPolicy : public MSIPolicy<MT, false, true> // always LLC, always not L1
+struct MirageMSIPolicy : public MSIPolicy<false, true, Outer> // always LLC, always not L1
 {
-  using CohPolicyBase::is_flush;
-  using CohPolicyBase::is_evict;
-public:
-  virtual void meta_after_flush(coh_cmd_t cmd, CMMetadataBase *meta) const override {
-    assert(is_flush(cmd));
-    if(is_evict(cmd)) {
-      static_cast<CT *>(CohPolicyBase::cache)->get_data_meta(static_cast<MT *>(meta))->to_invalid();
+  static __always_inline void meta_after_flush(coh_cmd_t cmd, CMMetadataBase *meta, CacheBase *cache) {
+    assert(coh::is_flush(cmd));
+    if(coh::is_evict(cmd)) {
+      static_cast<CT *>(cache)->get_data_meta(static_cast<MT *>(meta))->to_invalid();
       meta->to_invalid();
     }
   }

--- a/cache/msi.hpp
+++ b/cache/msi.hpp
@@ -19,89 +19,73 @@ using MetadataMSIBroadcast = MetadataBroadcast<AW, IW, TOfst, MetadataMSIBase<Me
 template <int AW, int IW, int TOfst>
 using MetadataMSIDirectory = MetadataDirectory<AW, IW, TOfst, MetadataMSIBase<MetadataDirectoryBase> >;
 
-template<typename MT, bool isL1, bool isLLC> requires C_DERIVE<MT, MetadataBroadcastBase>
-  class MSIPolicy : public MIPolicy<MT, isL1, isLLC>
+template<bool isL1, bool isLLC, typename Outer>
+struct MSIPolicy : public MIPolicy<isL1, isLLC, Outer>
 {
-  typedef MIPolicy<MT, isL1, isLLC> PolicT;
-protected:
-  using CohPolicyBase::outer;
-  using CohPolicyBase::is_release;
-  using CohPolicyBase::is_fetch_read;
-  using CohPolicyBase::is_fetch_write;
-  using CohPolicyBase::is_write;
-  using CohPolicyBase::is_evict;
-  using CohPolicyBase::is_writeback;
-  using CohPolicyBase::is_downgrade;
-  using CohPolicyBase::cmd_for_probe_release;
-  using CohPolicyBase::cmd_for_probe_writeback;
-  using CohPolicyBase::cmd_for_probe_downgrade;
-  using CohPolicyBase::cmd_for_null;
-
-public:
-  virtual coh_cmd_t cmd_for_outer_acquire(coh_cmd_t cmd) const override {
-    if(is_fetch_write(cmd) || is_evict(cmd) || is_writeback(cmd))
-      return this->cmd_for_write();
+  static __always_inline coh_cmd_t cmd_for_outer_acquire(coh_cmd_t cmd) {
+    if(coh::is_fetch_write(cmd) || coh::is_evict(cmd) || coh::is_writeback(cmd))
+      return coh::cmd_for_write();
     else
-      return this->cmd_for_read();
+      return coh::cmd_for_read();
   }
 
-  virtual std::pair<bool, coh_cmd_t> access_need_sync(coh_cmd_t cmd, const CMMetadataBase *meta) const override {
-    if(is_release(cmd))     return std::make_pair(false, cmd_for_null()); // assuming inclusive cache, release is always hit and exclusive/modified
-    if(is_fetch_write(cmd)) return std::make_pair(true, cmd_for_probe_release(cmd.id));
-    if(meta->is_shared())   return std::make_pair(false, cmd_for_null());
-    return std::make_pair(true, cmd_for_probe_downgrade(cmd.id));
+  static __always_inline std::pair<bool, coh_cmd_t> access_need_sync(coh_cmd_t cmd, const CMMetadataBase *meta) {
+    if(coh::is_release(cmd))     return std::make_pair(false, coh::cmd_for_null()); // for inclusive cache, release is always hit and exclusive/modified
+    if(coh::is_fetch_write(cmd)) return std::make_pair(true, coh::cmd_for_probe_release(cmd.id));
+    if(meta->is_shared())        return std::make_pair(false, coh::cmd_for_null());
+    return std::make_pair(true, coh::cmd_for_probe_downgrade(cmd.id));
   }
 
-  virtual std::tuple<bool, bool, coh_cmd_t> access_need_promote(coh_cmd_t cmd, const CMMetadataBase *meta) const override {
-    if(is_write(cmd)) {
-      if(!meta->allow_write())       return std::make_tuple(true,  false, this->cmd_for_write());
-      else if(!meta->is_modified())  return std::make_tuple(false, true,  cmd_for_null()); // promote locally
+  static __always_inline std::tuple<bool, bool, coh_cmd_t> access_need_promote(coh_cmd_t cmd, const CMMetadataBase *meta) {
+    if(coh::is_write(cmd)) {
+      if(!meta->allow_write())       return std::make_tuple(true,  false, coh::cmd_for_write());
+      else if(!meta->is_modified())  return std::make_tuple(false, true,  coh::cmd_for_null()); // promote locally
     }
-    return std::make_tuple(false, false, cmd_for_null());
+    return std::make_tuple(false, false, coh::cmd_for_null());
   }
 
-  virtual void meta_after_fetch(coh_cmd_t outer_cmd, CMMetadataBase *meta, uint64_t addr) const override {
+  static __always_inline void meta_after_fetch(coh_cmd_t outer_cmd, CMMetadataBase *meta, uint64_t addr) {
     meta->init(addr);
-    if(is_fetch_read(outer_cmd)) meta->to_shared(-1);
+    if(coh::is_fetch_read(outer_cmd)) meta->to_shared(-1);
     else {
-      assert(is_fetch_write(outer_cmd) && meta->allow_write());
+      assert(coh::is_fetch_write(outer_cmd) && meta->allow_write());
       meta->to_modified(-1);
     }
   }
 
-  virtual void meta_after_grant(coh_cmd_t cmd, CMMetadataBase *meta, CMMetadataBase *meta_inner) const override {
+  static __always_inline void meta_after_grant(coh_cmd_t cmd, CMMetadataBase *meta, CMMetadataBase *meta_inner) {
     int32_t id = cmd.id;
-    if(is_fetch_read(cmd)) {
+    if(coh::is_fetch_read(cmd)) {
       meta->to_shared(id);
       meta_inner->to_shared(-1);
     } else {
-      assert(is_fetch_write(cmd));
+      assert(coh::is_fetch_write(cmd));
       meta->to_modified(id);
       meta_inner->to_modified(-1);
     }
   }
 
-  virtual std::pair<bool, coh_cmd_t> probe_need_sync(coh_cmd_t outer_cmd, const CMMetadataBase *meta) const override {
+  static __always_inline std::pair<bool, coh_cmd_t> probe_need_sync(coh_cmd_t outer_cmd, const CMMetadataBase *meta) {
     if constexpr (!isL1) {
-      if(is_evict(outer_cmd))
-        return std::make_pair(true, cmd_for_probe_release());
+      if(coh::is_evict(outer_cmd))
+        return std::make_pair(true, coh::cmd_for_probe_release());
       else {
         if(meta && meta->is_shared())
-          return std::make_pair(false, cmd_for_null());
-        else if(is_downgrade(outer_cmd))
-          return std::make_pair(true, cmd_for_probe_downgrade());
+          return std::make_pair(false, coh::cmd_for_null());
+        else if(coh::is_downgrade(outer_cmd))
+          return std::make_pair(true, coh::cmd_for_probe_downgrade());
         else
-          return std::make_pair(true, cmd_for_probe_writeback());
+          return std::make_pair(true, coh::cmd_for_probe_writeback());
       }
-    } else return std::make_pair(false, cmd_for_null());
+    } else return std::make_pair(false, coh::cmd_for_null());
   }
 
-  virtual void meta_after_probe(coh_cmd_t outer_cmd, CMMetadataBase *meta, CMMetadataBase* meta_outer, int32_t inner_id, bool writeback) const override {
-    PolicT::meta_after_probe(outer_cmd, meta, meta_outer, inner_id, writeback);
+  static __always_inline void meta_after_probe(coh_cmd_t outer_cmd, CMMetadataBase *meta, CMMetadataBase* meta_outer, int32_t inner_id, bool writeback) {
+    MIPolicy<isL1, isLLC, Outer>::meta_after_probe(outer_cmd, meta, meta_outer, inner_id, writeback);
     if(meta) {
-      if(is_evict(outer_cmd))
+      if(coh::is_evict(outer_cmd))
         meta->to_invalid();
-      else if(is_downgrade(outer_cmd)) {
+      else if(coh::is_downgrade(outer_cmd)) {
         meta->get_outer_meta()->to_shared(-1);
         meta->to_shared(-1);
         meta->to_clean();
@@ -109,18 +93,18 @@ public:
     }
   }
 
-  virtual std::tuple<bool, bool, coh_cmd_t> flush_need_sync(coh_cmd_t cmd, const CMMetadataBase *meta, bool uncached) const override {
+  static __always_inline std::tuple<bool, bool, coh_cmd_t> flush_need_sync(coh_cmd_t cmd, const CMMetadataBase *meta, bool uncached) {
     if (isLLC || uncached) {
       if(meta) {
-        if(is_evict(cmd)) return std::make_tuple(true, true, cmd_for_probe_release());
+        if(coh::is_evict(cmd)) return std::make_tuple(true, true, coh::cmd_for_probe_release());
         else if(meta->is_shared())
-          return std::make_tuple(true, false, cmd_for_null());
+          return std::make_tuple(true, false, coh::cmd_for_null());
         else
-          return std::make_tuple(true, true, cmd_for_probe_writeback());
+          return std::make_tuple(true, true, coh::cmd_for_probe_writeback());
       } else
-        return std::make_tuple(true, false, cmd_for_null());
+        return std::make_tuple(true, false, coh::cmd_for_null());
     } else
-      return std::make_tuple(false, false, cmd_for_null());
+      return std::make_tuple(false, false, coh::cmd_for_null());
   }
 };
 

--- a/cache/replace.hpp
+++ b/cache/replace.hpp
@@ -119,9 +119,6 @@ public:
   }
 };
 
-template<int IW, int NW, bool EF = true, bool DUO = true>
-using ReplaceFIFO_MT = ReplaceFIFO<IW, NW, EF, DUO>;
-
 /////////////////////////////////
 // LRU replacement
 // IW: index width, NW: number of ways
@@ -150,9 +147,6 @@ public:
     RPT::delist_from_free(s, w, demand_acc);
   }
 };
-
-template<int IW, int NW, bool EF = true, bool DUO = true>
-using ReplaceLRU_MT = ReplaceLRU<IW, NW, EF, DUO>;
 
 /////////////////////////////////
 // Static RRIP replacement
@@ -197,9 +191,6 @@ public:
   }
 };
 
-template<int IW, int NW, bool EF = true, bool DUO = true>
-using ReplaceSRRIP_MT = ReplaceSRRIP<IW, NW, EF, DUO>;
-
 /////////////////////////////////
 // Random replacement
 // IW: index width, NW: number of ways
@@ -226,8 +217,5 @@ public:
     RPT::delist_from_free(s, w, demand_acc);
   }
 };
-
-template<int IW, int NW, bool EF = true, bool DUO = true>
-using ReplaceRandom_MT = ReplaceRandom<IW, NW, EF, DUO>;
 
 #endif

--- a/regression/c1-l1.cpp
+++ b/regression/c1-l1.cpp
@@ -1,4 +1,3 @@
-#include "cache/memory.hpp"
 #include "util/cache_type.hpp"
 #include "util/regression.hpp"
 
@@ -6,7 +5,8 @@
 #define TestN 512
 
 int main() {
-  auto cache = cache_gen_l1<4, 4, Data64B, MetadataBroadcastBase, ReplaceFIFO, MSIPolicy, true, true, void, true>(1, "l1d");
+  using policy_l1 = MSIPolicy<true, true, policy_memory>;
+  auto cache = cache_gen_l1<4, 4, Data64B, MetadataBroadcastBase, ReplaceFIFO, MSIPolicy, policy_l1, true, void, true>(1, "l1d");
   auto l1d = cache[0];
   auto core = get_l1_core_interface(cache);
   auto mem = new SimpleMemoryModel<Data64B,void,true>("mem");

--- a/regression/c2-l2-exc-mesi.cpp
+++ b/regression/c2-l2-exc-mesi.cpp
@@ -15,11 +15,14 @@
 #define L2DW 4
 
 int main() {
-  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, false, void, true>(NCore, "l1d");
+  using policy_l2 = ExclusiveMESIPolicy<false, true, policy_memory, true>;
+  using policy_l1d = MSIPolicy<true, false, policy_l2>;
+  using policy_l1i = MSIPolicy<true, true, policy_l2>;
+  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, policy_l1d, false, void, true>(NCore, "l1d");
   auto core_data = get_l1_core_interface(l1d);
-  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, true, void, true>(NCore, "l1i");
+  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, policy_l1i, true, void, true>(NCore, "l1i");
   auto core_inst = get_l1_core_interface(l1i);
-  auto l2 = cache_gen_l2_exc<L2IW, L2WN, L2DW, Data64B, MetadataDirectoryBase, ReplaceSRRIP, ReplaceLRU, MESIPolicy, true, void, true>(1, "l2")[0];
+  auto l2 = cache_gen_exc<L2IW, L2WN, L2DW, Data64B, MetadataDirectoryBase, ReplaceSRRIP, ReplaceLRU, ExclusiveMESIPolicy, policy_l2, true, void, true>(1, "l2")[0];
   auto mem = new SimpleMemoryModel<Data64B,void,true>("mem");
   SimpleTracer tracer(true);
 

--- a/regression/c2-l2-exc-mi.cpp
+++ b/regression/c2-l2-exc-mi.cpp
@@ -14,11 +14,14 @@
 #define L2WN 8
 
 int main() {
-  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MIPolicy, false, false, void, true>(NCore, "l1d");
+  using policy_l2 = ExclusiveMSIPolicy<false, true, policy_memory, false>;
+  using policy_l1d = MIPolicy<true, false, policy_l2>;
+  using policy_l1i = MSIPolicy<true, true, policy_l2>;
+  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MIPolicy, policy_l1d, false, void, true>(NCore, "l1d");
   auto core_data = get_l1_core_interface(l1d);
-  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, true, void, true>(NCore, "l1i");
+  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, policy_l1i, true, void, true>(NCore, "l1i");
   auto core_inst = get_l1_core_interface(l1i);
-  auto l2 = cache_gen_l2_exc<L2IW, L2WN, Data64B, MetadataBroadcastBase, ReplaceSRRIP, MSIPolicy, true, void, true>(1, "l2")[0];
+  auto l2 = cache_gen_exc<L2IW, L2WN, Data64B, MetadataBroadcastBase, ReplaceSRRIP, ExclusiveMSIPolicy, policy_l2, true, void, true>(1, "l2")[0];
   auto mem = new SimpleMemoryModel<Data64B,void,true>("mem");
   SimpleTracer tracer(true);
 

--- a/regression/c2-l2-exc.cpp
+++ b/regression/c2-l2-exc.cpp
@@ -14,11 +14,14 @@
 #define L2WN 8
 
 int main() {
-  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, false, void, true>(NCore, "l1d");
+  using policy_l2 = ExclusiveMSIPolicy<false, true, policy_memory, false>;
+  using policy_l1d = MSIPolicy<true, false, policy_l2>;
+  using policy_l1i = MSIPolicy<true, true, policy_l2>;
+  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, policy_l1d, false, void, true>(NCore, "l1d");
   auto core_data = get_l1_core_interface(l1d);
-  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, true, void, true>(NCore, "l1i");
+  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, policy_l1i, true, void, true>(NCore, "l1i");
   auto core_inst = get_l1_core_interface(l1i);
-  auto l2 = cache_gen_l2_exc<L2IW, L2WN, Data64B, MetadataBroadcastBase, ReplaceSRRIP, MSIPolicy, true, void, true>(1, "l2")[0];
+  auto l2 = cache_gen_exc<L2IW, L2WN, Data64B, MetadataBroadcastBase, ReplaceSRRIP, ExclusiveMSIPolicy, policy_l2, true, void, true>(1, "l2")[0];
   auto mem = new SimpleMemoryModel<Data64B,void,true>("mem");
   SimpleTracer tracer(true);
 

--- a/regression/c2-l2-mesi.cpp
+++ b/regression/c2-l2-mesi.cpp
@@ -14,11 +14,14 @@
 #define L2WN 8
 
 int main() {
-  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, false, void, true>(NCore, "l1d");
+  using policy_l2 = MESIPolicy<false, true, policy_memory>;
+  using policy_l1d = MSIPolicy<true, false, policy_l2>;
+  using policy_l1i = MSIPolicy<true, true, policy_l2>;
+  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, policy_l1d, false, void, true>(NCore, "l1d");
   auto core_data = get_l1_core_interface(l1d);
-  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, true, void, true>(NCore, "l1i");
+  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, policy_l1i, true, void, true>(NCore, "l1i");
   auto core_inst = get_l1_core_interface(l1i);
-  auto l2 = cache_gen_l2_inc<L2IW, L2WN, Data64B, MetadataDirectoryBase, ReplaceSRRIP, MESIPolicy, true, void, true>(1, "l2")[0];
+  auto l2 = cache_gen_inc<L2IW, L2WN, Data64B, MetadataBroadcastBase, ReplaceSRRIP, MESIPolicy, policy_l2, true, void, true>(1, "l2")[0];
   auto mem = new SimpleMemoryModel<Data64B,void,true>("mem");
   SimpleTracer tracer(true);
 

--- a/regression/c2-l2-mirage.cpp
+++ b/regression/c2-l2-mirage.cpp
@@ -17,11 +17,15 @@
 #define L2RN 2
 
 int main() {
-  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, false, void, true>(NCore, "l1d");
+  using mirage_gen = ct::mirage::types<L2IW, L2WN, L2EW, L2P, L2RN, Data64B, ReplaceSRRIP, ReplaceRandom, policy_memory, void, true, true>;
+  using policy_l2 = mirage_gen::policy_type;
+  using policy_l1d = MSIPolicy<true, false, policy_l2>;
+  using policy_l1i = MSIPolicy<true, true, policy_l2>;
+  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, policy_l1d, false, void, true>(NCore, "l1d");
   auto core_data = get_l1_core_interface(l1d);
-  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, true, void, true>(NCore, "l1i");
+  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, policy_l1i, true, void, true>(NCore, "l1i");
   auto core_inst = get_l1_core_interface(l1i);
-  auto l2 = cache_gen_llc_mirage<L2IW, L2WN, L2EW, L2P, L2RN, Data64B, ReplaceSRRIP, ReplaceRandom, void, true, true>(1, "l2")[0];
+  auto l2 = mirage_gen::cache_gen_mirage(1, "l2")[0];
   auto mem = new SimpleMemoryModel<Data64B,void,true>("mem");
   SimpleTracer tracer(true);
 

--- a/regression/c2-l2.cpp
+++ b/regression/c2-l2.cpp
@@ -14,11 +14,14 @@
 #define L2WN 8
 
 int main() {
-  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, false, void, true>(NCore, "l1d");
+  using policy_l2 = MSIPolicy<false, true, policy_memory>;
+  using policy_l1d = MSIPolicy<true, false, policy_l2>;
+  using policy_l1i = MSIPolicy<true, true, policy_l2>;
+  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, policy_l1d, false, void, true>(NCore, "l1d");
   auto core_data = get_l1_core_interface(l1d);
-  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, true, void, true>(NCore, "l1i");
+  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, policy_l1i, true, void, true>(NCore, "l1i");
   auto core_inst = get_l1_core_interface(l1i);
-  auto l2 = cache_gen_l2_inc<L2IW, L2WN, Data64B, MetadataBroadcastBase, ReplaceSRRIP, MSIPolicy, true, void, true>(1, "l2")[0];
+  auto l2 = cache_gen_inc<L2IW, L2WN, Data64B, MetadataBroadcastBase, ReplaceSRRIP, MSIPolicy, policy_l2, true, void, true>(1, "l2")[0];
   auto mem = new SimpleMemoryModel<Data64B,void,true>("mem");
   SimpleTracer tracer(true);
 

--- a/regression/c4-l3-exc-mesi.cpp
+++ b/regression/c4-l3-exc-mesi.cpp
@@ -18,12 +18,16 @@
 #define L3DW 5
 
 int main() {
-  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, false, void, true>(NCore, "l1d");
+  using policy_l3 = ExclusiveMESIPolicy<false, true, policy_memory, true>;
+  using policy_l2 = MSIPolicy<false, false, policy_l3>;
+  using policy_l1d = MSIPolicy<true, false, policy_l2>;
+  using policy_l1i = MSIPolicy<true, true, policy_l2>;
+  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, policy_l1d, false, void, true>(NCore, "l1d");
   auto core_data = get_l1_core_interface(l1d);
-  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, true, void, true>(NCore, "l1i");
+  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, policy_l1i, true, void, true>(NCore, "l1i");
   auto core_inst = get_l1_core_interface(l1i);
-  auto l2 = cache_gen_l2_inc<L2IW, L2WN, Data64B, MetadataBroadcastBase, ReplaceSRRIP, MSIPolicy, false, void, true>(NCore, "l2");
-  auto l3 = cache_gen_llc_exc<L3IW, L3WN, L3DW, Data64B, MetadataDirectoryBase, ReplaceSRRIP, ReplaceLRU, MESIPolicy, void, true>(1, "l3")[0];
+  auto l2 = cache_gen_inc<L2IW, L2WN, Data64B, MetadataBroadcastBase, ReplaceSRRIP, MSIPolicy, policy_l2, false, void, true>(NCore, "l2");
+  auto l3 = cache_gen_exc<L3IW, L3WN, L3DW, Data64B, MetadataDirectoryBase, ReplaceSRRIP, ReplaceLRU, ExclusiveMESIPolicy, policy_l3, true, void, true>(1, "l3")[0];
   auto mem = new SimpleMemoryModel<Data64B,void,true>("mem");
   SimpleTracer tracer(true);
 

--- a/regression/c4-l3-exc.cpp
+++ b/regression/c4-l3-exc.cpp
@@ -17,12 +17,16 @@
 #define L3WN 11
 
 int main() {
-  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, false, void, true>(NCore, "l1d");
+  using policy_l3 = ExclusiveMSIPolicy<false, true, policy_memory, false>;
+  using policy_l2 = MSIPolicy<false, false, policy_l3>;
+  using policy_l1d = MSIPolicy<true, false, policy_l2>;
+  using policy_l1i = MSIPolicy<true, true, policy_l2>;
+  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, policy_l1d, false, void, true>(NCore, "l1d");
   auto core_data = get_l1_core_interface(l1d);
-  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, true, void, true>(NCore, "l1i");
+  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, policy_l1i, true, void, true>(NCore, "l1i");
   auto core_inst = get_l1_core_interface(l1i);
-  auto l2 = cache_gen_l2_inc<L2IW, L2WN, Data64B, MetadataBroadcastBase, ReplaceSRRIP, MSIPolicy, false, void, true>(NCore, "l2");
-  auto l3 = cache_gen_llc_exc<L3IW, L3WN, Data64B, MetadataBroadcastBase, ReplaceSRRIP, MSIPolicy, void, true>(1, "l3")[0];
+  auto l2 = cache_gen_inc<L2IW, L2WN, Data64B, MetadataBroadcastBase, ReplaceSRRIP, MSIPolicy, policy_l2, false, void, true>(NCore, "l2");
+  auto l3 = cache_gen_exc<L3IW, L3WN, Data64B, MetadataBroadcastBase, ReplaceSRRIP, ExclusiveMSIPolicy, policy_l3, true, void, true>(1, "l3")[0];
   auto mem = new SimpleMemoryModel<Data64B,void,true>("mem");
   SimpleTracer tracer(true);
 

--- a/regression/c4-l3-intel.cpp
+++ b/regression/c4-l3-intel.cpp
@@ -18,12 +18,16 @@
 #define L3WN 16
 
 int main() {
-  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, false, void, true>(NCore, "l1d");
+  using policy_l3 = MESIPolicy<false, true, policy_memory>;
+  using policy_l2 = ExclusiveMSIPolicy<false, false, policy_l3, false>;
+  using policy_l1d = MSIPolicy<true, false, policy_l2>;
+  using policy_l1i = MSIPolicy<true, true, policy_l2>;
+  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, policy_l1d, false, void, true>(NCore, "l1d");
   auto core_data = get_l1_core_interface(l1d);
-  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, true, void, true>(NCore, "l1i");
+  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, policy_l1i, true, void, true>(NCore, "l1i");
   auto core_inst = get_l1_core_interface(l1i);
-  auto l2 = cache_gen_l2_exc<L2IW, L2WN, Data64B, MetadataBroadcastBase, ReplaceSRRIP, MSIPolicy, false, void, true>(NCore, "l2");
-  auto l3 = cache_gen_llc_inc<L3IW, L3WN, Data64B, MetadataDirectoryBase, ReplaceSRRIP, MESIPolicy, void, true>(NCore, "l3");
+  auto l2 = cache_gen_exc<L2IW, L2WN, Data64B, MetadataBroadcastBase, ReplaceSRRIP, ExclusiveMSIPolicy, policy_l2, false, void, true>(NCore, "l2");
+  auto l3 = cache_gen_inc<L3IW, L3WN, Data64B, MetadataDirectoryBase, ReplaceSRRIP, MESIPolicy, policy_l3, true, void, true>(NCore, "l3");
   auto dispatcher = new SliceDispatcher<SliceHashIntelCAS>("disp", NCore);
   auto mem = new SimpleMemoryModel<Data64B,void,true>("mem");
   SimpleTracer tracer(true);

--- a/regression/c4-l3.cpp
+++ b/regression/c4-l3.cpp
@@ -17,12 +17,16 @@
 #define L3WN 16
 
 int main() {
-  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, false, void, true>(NCore, "l1d");
+  using policy_l3 = MSIPolicy<false, true, policy_memory>;
+  using policy_l2 = MSIPolicy<false, false, policy_l3>;
+  using policy_l1d = MSIPolicy<true, false, policy_l2>;
+  using policy_l1i = MSIPolicy<true, true, policy_l2>;
+  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, policy_l1d, false, void, true>(NCore, "l1d");
   auto core_data = get_l1_core_interface(l1d);
-  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, false, true, void, true>(NCore, "l1i");
+  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, policy_l1i, true, void, true>(NCore, "l1i");
   auto core_inst = get_l1_core_interface(l1i);
-  auto l2 = cache_gen_l2_inc<L2IW, L2WN, Data64B, MetadataBroadcastBase, ReplaceSRRIP, MSIPolicy, false, void, true>(NCore, "l2");
-  auto l3 = cache_gen_llc_inc<L3IW, L3WN, Data64B, MetadataBroadcastBase, ReplaceSRRIP, MSIPolicy, void, true>(1, "l3")[0];
+  auto l2 = cache_gen_inc<L2IW, L2WN, Data64B, MetadataBroadcastBase, ReplaceSRRIP, MSIPolicy, policy_l2, false, void, true>(NCore, "l2");
+  auto l3 = cache_gen_inc<L3IW, L3WN, Data64B, MetadataBroadcastBase, ReplaceSRRIP, MSIPolicy, policy_l3, true, void, true>(1, "l3")[0];
   auto mem = new SimpleMemoryModel<Data64B,void,true>("mem");
   SimpleTracer tracer(true);
 

--- a/regression/multi-l2-msi.cpp
+++ b/regression/multi-l2-msi.cpp
@@ -26,12 +26,14 @@ PrintPool *globalPrinter;
 #endif
 
 int main(){
-  auto l1d = cache_gen_multi_thread_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU_MT, MSIPolicy, false, false, void, true>(NCore, "l1d");
+  using policy_l2 = MSIPolicy<false, true, policy_memory>;
+  using policy_l1d = MSIPolicy<true, false, policy_l2>;
+  using policy_l1i = MSIPolicy<true, true, policy_l2>;
+  auto l1d = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, policy_l1d, false, void, true, true>(NCore, "l1d");
   auto core_data = get_l1_core_interface(l1d);
-  auto l1i = cache_gen_multi_thread_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU_MT, MSIPolicy, false, true, void, true>(NCore, "l1i");
+  auto l1i = cache_gen_l1<L1IW, L1WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, policy_l1i, true, void, true, true>(NCore, "l1i");
   auto core_inst = get_l1_core_interface(l1i);
-
-  auto l2 = cache_gen_multi_thread_l2<L2IW, L2WN, Data64B, MetadataBroadcastBase, ReplaceLRU_MT, MSIPolicy, true, void, true>(1, "l2")[0];
+  auto l2 = cache_gen_inc<L2IW, L2WN, Data64B, MetadataBroadcastBase, ReplaceLRU, MSIPolicy, policy_l2, true, void, true, true>(1, "l2")[0];
   auto mem = new SimpleMemoryModel<Data64B, void, true, true>("mem");
   globalPrinter = new PrintPool(256);
   SimpleTracerMT tracer(true);

--- a/util/cache_type.hpp
+++ b/util/cache_type.hpp
@@ -8,13 +8,72 @@
 #include "cache/mesi.hpp"
 #include "cache/index.hpp"
 #include "cache/replace.hpp"
+#include "cache/memory.hpp"
 
+namespace ct {
+  template<typename MT>
+  constexpr bool is_dir() { return std::is_same_v<MT, MetadataDirectoryBase>; }
 
-template<typename CT, typename CPT>
+  template<template <bool, bool, typename> class CPT>
+  constexpr bool is_inc_mi() {
+    return std::is_same_v<CPT<false, true, CohPolicyBase>, MIPolicy<false, true, CohPolicyBase> >;
+  }
+
+  template<template <bool, bool, typename> class CPT>
+  constexpr bool is_inc_msi() {
+    return std::is_same_v<CPT<false, true, CohPolicyBase>, MSIPolicy<false, true, CohPolicyBase> >;
+  }
+
+  template<template <bool, bool, typename> class CPT>
+  constexpr bool is_inc_mesi() {
+    return std::is_same_v<CPT<false, true, CohPolicyBase>, MESIPolicy<false, true, CohPolicyBase> >;
+  }
+
+  template<template <bool, bool, typename> class CPT>
+  constexpr bool is_exc_msi() {
+    return std::is_same_v<CPT<false, true, CohPolicyBase>, ExclusiveMSIPolicy<false, true, CohPolicyBase> >;
+  }
+
+  template<template <bool, bool, typename> class CPT>
+  constexpr bool is_exc_mesi() {
+    return std::is_same_v<CPT<false, true, CohPolicyBase>, ExclusiveMESIPolicy<false, true, CohPolicyBase> >;
+  }
+
+  template<bool isDir, typename MTDir, typename MTBCast>
+  using metadata_sel_dir = std::conditional_t<isDir, MTDir, MTBCast>;
+
+  template<template <bool, bool, typename> class CPT, typename MT, int IW>
+  using metadata_type =
+    std::conditional_t<is_inc_mi<CPT>(), MetadataMIBroadcast<48, IW, IW+6>,
+    std::conditional_t<is_inc_msi<CPT>() || is_exc_msi<CPT>(), metadata_sel_dir<is_dir<MT>(), MetadataMSIDirectory<48, IW, IW+6>, MetadataMSIBroadcast<48, IW, IW+6> >,
+    std::conditional_t<is_inc_mesi<CPT>() || is_exc_mesi<CPT>(), MetadataMESIDirectory<48, IW, IW+6>,
+                       void> > >;
+
+  template<typename Policy, bool isDir, bool EnMT>
+  using input_port_exc = std::conditional_t<isDir, ExclusiveInnerCohPortDirectory<Policy, EnMT>,
+                                            ExclusiveInnerCohPortBroadcast<Policy, EnMT> >;
+
+  template<typename Policy, bool isL1, bool isDir, bool isExc, bool EnMT>
+  using input_port_type =
+    std::conditional_t<isL1, CoreInterface<Policy, EnMT>,
+    std::conditional_t<isExc, input_port_exc<Policy, isDir, EnMT>,
+                       InnerCohPort<Policy, EnMT> > >;
+
+  template<typename Policy, bool isDir, bool EnMT>
+  using output_port_exc = std::conditional_t<isDir, ExclusiveOuterCohPortDirectory<Policy, EnMT>,
+                                             ExclusiveOuterCohPortBroadcast<Policy, EnMT> >;
+
+  template<typename Policy, bool uncached, bool isDir, bool isExc, bool EnMT>
+  using output_port_type =
+    std::conditional_t<uncached, OuterCohPortUncached<Policy, EnMT>,
+    std::conditional_t<isExc, output_port_exc<Policy, isDir, EnMT>,
+                       OuterCohPort<Policy, EnMT> > >;
+}
+
+template<typename CT>
 inline std::vector<CoherentCacheBase *> cache_generator(int size, const std::string& name_prefix) {
-  policy_ptr policy(new CPT());
   auto array = std::vector<CoherentCacheBase *>(size);
-  for(int i=0; i<size; i++) array[i] = new CT(policy, name_prefix + (size > 1 ? "-"+std::to_string(i) : ""));
+  for(int i=0; i<size; i++) array[i] = new CT(name_prefix + (size > 1 ? "-"+std::to_string(i) : ""));
   return array;
 }
 
@@ -25,129 +84,65 @@ inline auto get_l1_core_interface(std::vector<CoherentCacheBase *>& array) {
   return core;
 }
 
-template<int IW, int WN, int DW, typename DT, typename MBT,
+template<int IW, int WN, int DW, typename DT, typename MT,
          template <int, int, bool> class RPT,
          template <int, int, bool> class DRPT,
-         template <typename, bool, bool> class CPT,
-         bool isL1, bool isLLC, bool uncache, bool isExc, typename DLY, bool EnMon>
-inline auto cache_type_compile(int size, const std::string& name_prefix) {
-  typedef IndexNorm<IW,6> index_type;
-  typedef RPT<IW,WN,true> replace_type;
-  typedef DRPT<IW,DW,true> ext_replace_type;
+         template <bool, bool, typename> class CPT, typename Policy,
+         bool isL1, bool uncached, typename DLY, bool EnMon, bool EnMT>
+inline auto cache_gen(int size, const std::string& name_prefix) {
+  using index_type = IndexNorm<IW,6>;
+  using replace_type = RPT<IW,WN,true>;
+  using ext_replace_type = DRPT<IW,DW,true>;
+  constexpr bool isDir = ct::is_dir<MT>();
+  constexpr bool isExc = ct::is_exc_msi<CPT>() || ct::is_exc_mesi<CPT>();
+  static_assert(!(isExc && EnMT), "multithread support ia not available for exclusive caches!");
+  using metadata_type = ct::metadata_type<CPT, MT, IW>;
+  using input_type = ct::input_port_type<Policy, isL1, isDir, isExc, EnMT>;
+  using output_type = ct::output_port_type<Policy, uncached, isDir, isExc, EnMT>;
+  using cache_base_type =
+    std::conditional_t<isExc,
+    std::conditional_t<isDir,
+      CacheNormExclusiveDirectory<IW, WN, DW, metadata_type, DT, index_type, replace_type, ext_replace_type, DLY, EnMon>,
+      CacheNormExclusiveBroadcast<IW, WN,     metadata_type, DT, index_type, replace_type,                   DLY, EnMon> >,
+                        CacheNorm<IW, WN,     metadata_type, DT, index_type, replace_type,                   DLY, EnMon, EnMT> >;
 
-  constexpr bool isDir  = std::is_same_v<MBT, MetadataDirectoryBase>;
-  constexpr bool isMESI = std::is_same_v<CPT<MetadataDirectoryBase, false, true>, MESIPolicy<MetadataDirectoryBase, false, true> >;
-  constexpr bool isMSI  = std::is_same_v<CPT<MetadataDirectoryBase, false, true>, MSIPolicy<MetadataDirectoryBase, false, true> >;
-  constexpr bool isMI   = std::is_same_v<CPT<MetadataDirectoryBase, false, true>, MIPolicy<MetadataDirectoryBase, false, true> >;
-
-  // ports
-  typedef typename std::conditional<isL1, CoreInterface<false>,
-                                    typename std::conditional<isExc,
-                                      typename std::conditional<isDir, ExclusiveInnerCohPortDirectory<false>, ExclusiveInnerCohPortBroadcast<false> >::type,
-                                      InnerCohPort<false> >::type >::type input_type;
-  typedef typename std::conditional<isLLC || uncache, OuterCohPortUncached<false>,
-                                    typename std::conditional<isExc,
-                                      typename std::conditional<isDir, ExclusiveOuterCohPortDirectory<false>, ExclusiveOuterCohPortBroadcast<false> >::type,
-                                      OuterCohPort<false> >::type >::type output_type;
-
-  // MESI
-  typedef MetadataMESIDirectory<48, IW, IW+6> mesi_metadata_type;
-  typedef typename std::conditional<isExc,
-                                    ExclusiveMESIPolicy<mesi_metadata_type, true, isLLC>,
-                                    MESIPolicy<mesi_metadata_type, false, isLLC>
-                                    >::type mesi_policy_type;
-  if constexpr (isMESI && isExc) assert(isDir);
-
-  // MSI
-  typedef typename std::conditional<isDir, MetadataMSIDirectory<48, IW, IW+6>, MetadataMSIBroadcast<48, IW, IW+6> >::type msi_metadata_type;
-  typedef typename std::conditional<isExc,
-                                    ExclusiveMSIPolicy<msi_metadata_type, isDir, isLLC>,
-                                    MSIPolicy<msi_metadata_type, isL1, isLLC>
-                                    >::type msi_policy_type;
-
-  // MI
-  typedef MetadataMIBroadcast<48, IW, IW+6> mi_metadata_type;
-  typedef MIPolicy<mi_metadata_type, true, isLLC> mi_policy_type;
-  if constexpr (isMI) assert(!isDir && !isExc);
-
-  typedef typename std::conditional<isMESI, mesi_metadata_type,
-          typename std::conditional<isMSI,  msi_metadata_type,
-                                            mi_metadata_type>::type >::type metadata_type;
-
-  typedef typename std::conditional<isMESI, mesi_policy_type,
-          typename std::conditional<isMSI,  msi_policy_type,
-                                            mi_policy_type>::type >::type policy_type;
-
-  typedef typename std::conditional<
-    isExc, typename std::conditional<
-             isDir, CacheNormExclusiveDirectory<IW, WN, DW, metadata_type, DT, index_type, replace_type, ext_replace_type, DLY, EnMon>,
-                    CacheNormExclusiveBroadcast<IW, WN,     metadata_type, DT, index_type, replace_type,                   DLY, EnMon> >::type,
-           CacheNorm<IW, WN, metadata_type, DT, index_type, replace_type, DLY, EnMon> >::type cache_base_type;
-
-  typedef CoherentCacheNorm<cache_base_type, output_type, input_type> cache_type;
-  return cache_generator<cache_type, policy_type>(size, name_prefix);
+  using cache_type = CoherentCacheNorm<cache_base_type, output_type, input_type>;
+  return cache_generator<cache_type>(size, name_prefix);
 }
 
-template<int IW, int WN, typename DT, typename MBT,
+template<int IW, int WN, typename DT, typename MT,
          template <int, int, bool> class RPT,
-         template <typename, bool, bool> class CPT,
-         bool isLLC, bool uncache, typename DLY, bool EnMon>
+         template <bool, bool, typename> class CPT, typename Policy,
+         bool uncached, typename DLY, bool EnMon, bool EnMT = false>
 inline auto cache_gen_l1(int size, const std::string& name_prefix) {
-  return cache_type_compile<IW, WN, 1, DT, MBT, RPT, ReplaceLRU, CPT, true, isLLC, uncache, false, DLY, EnMon>(size, name_prefix);
+  return cache_gen<IW, WN, 1, DT, MT, RPT, ReplaceLRU, CPT, Policy, true, uncached, DLY, EnMon, EnMT>(size, name_prefix);
 }
 
-template<int IW, int WN, typename DT, typename MBT,
+template<int IW, int WN, typename DT, typename MT,
          template <int, int, bool> class RPT,
-         template <typename, bool, bool> class CPT,
-         bool isLLC, typename DLY, bool EnMon>
-inline auto cache_gen_l2_inc(int size, const std::string& name_prefix) {
-  return cache_type_compile<IW, WN, 1, DT, MBT, RPT, ReplaceLRU, CPT, false, isLLC, false, false, DLY, EnMon>(size, name_prefix);
+         template <bool, bool, typename> class CPT, typename Policy,
+         bool uncached, typename DLY, bool EnMon, bool EnMT = false>
+inline auto cache_gen_inc(int size, const std::string& name_prefix) {
+  return cache_gen<IW, WN, 1, DT, MT, RPT, ReplaceLRU, CPT, Policy, false, uncached, DLY, EnMon, EnMT>(size, name_prefix);
 }
 
-template<int IW, int WN, typename DT, typename MBT,
+template<int IW, int WN, typename DT, typename MT,
          template <int, int, bool> class RPT,
-         template <typename, bool, bool> class CPT,
-         bool isLLC, typename DLY, bool EnMon>
-inline auto cache_gen_l2_exc(int size, const std::string& name_prefix) {
-  return cache_type_compile<IW, WN, 1,  DT, MBT, RPT, ReplaceLRU, CPT, false, isLLC, false, true, DLY, EnMon>(size, name_prefix);
+         template <bool, bool, typename> typename CPT, typename Policy,
+         bool uncached, typename DLY, bool EnMon>
+inline auto cache_gen_exc(int size, const std::string& name_prefix) {
+  static_assert(ct::is_exc_msi<CPT>());
+  return cache_gen<IW, WN, 1, DT, MT, RPT, ReplaceLRU, CPT, Policy, false, uncached, DLY, EnMon, false>(size, name_prefix);
 }
 
-template<int IW, int WN, int DW, typename DT, typename MBT,
-         template <int, int, bool> class RPT,
-         template <int, int, bool> class DRPT,
-         template <typename, bool, bool> class CPT,
-         bool isLLC, typename DLY, bool EnMon>
-inline auto cache_gen_l2_exc(int size, const std::string& name_prefix) {
-  constexpr bool isDir  = std::is_same_v<MBT, MetadataDirectoryBase>;
-  assert(isDir);
-  return cache_type_compile<IW, WN, DW, DT, MBT, RPT, DRPT,       CPT, false, isLLC, false, true, DLY, EnMon>(size, name_prefix);
-}
-
-template<int IW, int WN, typename DT, typename MBT,
-         template <int, int, bool> class RPT,
-         template <typename, bool, bool> class CPT,
-         typename DLY, bool EnMon>
-inline auto cache_gen_llc_inc(int size, const std::string& name_prefix) {
-  return cache_type_compile<IW, WN, 1, DT, MBT, RPT, ReplaceLRU, CPT, false, true, false, false, DLY, EnMon>(size, name_prefix);
-}
-
-template<int IW, int WN, typename DT, typename MBT,
-         template <int, int, bool> class RPT,
-         template <typename, bool, bool> class CPT,
-         typename DLY, bool EnMon>
-inline auto cache_gen_llc_exc(int size, const std::string& name_prefix) {
-  return cache_type_compile<IW, WN, 1,  DT, MBT, RPT, ReplaceLRU, CPT, false, true, false, true, DLY, EnMon>(size, name_prefix);
-}
-
-template<int IW, int WN, int DW, typename DT, typename MBT,
+template<int IW, int WN, int DW, typename DT, typename MT,
          template <int, int, bool> class RPT,
          template <int, int, bool> class DRPT,
-         template <typename, bool, bool> class CPT,
-         typename DLY, bool EnMon>
-inline auto cache_gen_llc_exc(int size, const std::string& name_prefix) {
-  constexpr bool isDir  = std::is_same_v<MBT, MetadataDirectoryBase>;
-  assert(isDir);
-  return cache_type_compile<IW, WN, DW, DT, MBT, RPT, DRPT,       CPT, false, true, false, true, DLY, EnMon>(size, name_prefix);
+         template <bool, bool, typename> class CPT, typename Policy,
+         bool uncached, typename DLY, bool EnMon>
+inline auto cache_gen_exc(int size, const std::string& name_prefix) {
+  static_assert(ct::is_exc_mesi<CPT>() && ct::is_dir<MT>());
+  return cache_gen<IW, WN, DW, DT, MT, RPT, DRPT, CPT, Policy, false, uncached, DLY, EnMon, false>(size, name_prefix);
 }
 
 template<int IW, int WN, int EW, int P, int MaxRelocN, typename DT,
@@ -171,73 +166,5 @@ inline auto cache_gen_llc_mirage(int size, const std::string& name_prefix) {
   typedef CoherentCacheNorm<cache_base_type, OuterCohPortUncached<false>, MirageInnerCohPort<meta_metadata_type, cache_base_type, false> > cache_type;
   return cache_generator<cache_type, policy_type>(size, name_prefix);
 }
-
-template<int IW, int WN, typename DT, typename MBT,
-         template <int, int, bool> class RPT,
-         template <typename, bool, bool> class CPT,
-         bool isL1, bool isLLC, bool uncache, typename DLY, bool EnMon>
-inline auto cache_multi_thread_type_compile(int size, const std::string& name_prefix){
-  typedef IndexNorm<IW,6> index_type;
-  typedef RPT<IW,WN,true> replace_type;
-
-  constexpr bool isDir  = std::is_same_v<MBT, MetadataDirectoryBase>;
-  constexpr bool isMESI = std::is_same_v<CPT<MetadataDirectoryBase, false, true>, MESIPolicy<MetadataDirectoryBase, false, true> >;
-  constexpr bool isMSI  = std::is_same_v<CPT<MetadataDirectoryBase, false, true>, MSIPolicy<MetadataDirectoryBase, false, true> >;
-
-  // MESI
-  typedef MetadataMESIDirectory<48, IW, IW+6> mesi_metadata_type;
-  typedef MESIPolicy<mesi_metadata_type, false, isLLC> mesi_policy_type;
-
-  // MSI
-  typedef typename std::conditional<isDir, MetadataMSIDirectory<48, IW, IW+6>, MetadataMSIBroadcast<48, IW, IW+6> >::type msi_metadata_type;
-  typedef MSIPolicy<msi_metadata_type, isL1, isLLC> msi_policy_type;
-
-  // MI
-  typedef MetadataMIBroadcast<48, IW, IW+6> mi_metadata_type;
-  typedef MIPolicy<mi_metadata_type, true, isLLC> mi_policy_type;
-
-  typedef typename std::conditional<isMESI, mesi_metadata_type,
-          typename std::conditional<isMSI,  msi_metadata_type,
-                                            mi_metadata_type>::type >::type metadata_type;
-  typedef typename std::conditional<isMESI, mesi_policy_type,
-          typename std::conditional<isMSI,  msi_policy_type,
-                                            mi_policy_type>::type >::type policy_type;
-
-  typedef CacheNorm<IW, WN, metadata_type, DT, index_type, replace_type, DLY, EnMon, true, true, 4> cache_base_type;
-
-  typedef typename std::conditional<isL1, CoreInterface<true>, InnerCohPort<true> >::type input_type;
-  
-  typedef typename std::conditional<isLLC || uncache, OuterCohPortUncached<true>, OuterCohPortT<OuterCohPortUncached<true>, true> >::type output_type;
-
-  typedef CoherentCacheNorm<cache_base_type, output_type, input_type> cache_type;
-
-  return cache_generator<cache_type, policy_type>(size, name_prefix);
-}
-
-
-template<int IW, int WN, typename DT, typename MBT,
-         template <int, int, bool> class RPT,
-         template <typename, bool, bool> class CPT,
-         bool isLLC, bool uncache, typename DLY, bool EnMon>
-inline auto cache_gen_multi_thread_l1(int size, const std::string& name_prefix) {
-  return cache_multi_thread_type_compile<IW, WN, DT, MBT, RPT, CPT, true, isLLC, uncache, DLY, EnMon>(size, name_prefix);
-}
-
-template<int IW, int WN, typename DT, typename MBT,
-         template <int, int, bool> class RPT,
-         template <typename, bool, bool> class CPT,
-         bool isLLC, typename DLY, bool EnMon>
-inline auto cache_gen_multi_thread_l2(int size, const std::string& name_prefix){
-  return cache_multi_thread_type_compile<IW, WN, DT, MBT, RPT, CPT, false, isLLC, false, DLY, EnMon>(size, name_prefix);
-}
-
-template<int IW, int WN, typename DT, typename MBT,
-         template <int, int, bool> class RPT,
-         template <typename, bool, bool> class CPT,
-         typename DLY, bool EnMon>
-inline auto cache_gen_multi_thread_llc(int size, const std::string& name_prefix){
-  return cache_multi_thread_type_compile<IW, WN, DT, MBT, RPT, CPT, false, true, false, DLY, EnMon>(size, name_prefix);
-}
-
 
 #endif


### PR DESCRIPTION
The previous policy classes utilize the COO virtual functions for supporting different policies. However, virtual function is a run-time feature which rely on an actual object in memory with indirect call using vtables. This would cost both memory and run-time cycles. This PR replace the runtime objects with static classes and rely on compile-time template parameters to decide coherence policy. The derived coherence functions are implemented using overload rather than override.