### PR TITLE
Support prefetch

### DIFF
--- a/cache/cache.hpp
+++ b/cache/cache.hpp
@@ -316,8 +316,8 @@ public:
     }
   }
 
-  virtual void hook_read(uint64_t addr, uint32_t ai, uint32_t s, uint32_t w, bool hit, const CMMetadataBase * meta, const CMDataBase *data, uint64_t *delay) override {
-    if(ai < P) replacer[ai].access(s, w, true, false);
+  virtual void hook_read(uint64_t addr, uint32_t ai, uint32_t s, uint32_t w, bool hit, bool prefetch, const CMMetadataBase * meta, const CMDataBase *data, uint64_t *delay) override {
+    if(ai < P) replacer[ai].access(s, w, true, prefetch);
     if constexpr (EnMon || !C_VOID<DLY>) monitors->hook_read(addr, ai, s, w, hit, meta, data, delay);
   }
 

--- a/cache/coh_policy.hpp
+++ b/cache/coh_policy.hpp
@@ -30,6 +30,7 @@ namespace coh {
   const uint32_t evict_act       = 2;
   const uint32_t writeback_act   = 3;
   const uint32_t downgrade_act   = 4;
+  const uint32_t prefetch_act    = 5;
 
   // message type
   constexpr inline bool is_acquire(coh_cmd_t cmd)        { return cmd.msg == acquire_msg;     }
@@ -45,10 +46,12 @@ namespace coh {
   constexpr inline bool is_writeback(coh_cmd_t cmd)      { return cmd.act == writeback_act;   }
   constexpr inline bool is_downgrade(coh_cmd_t cmd)      { return cmd.act == downgrade_act;   }
   constexpr inline bool is_write(coh_cmd_t cmd)          { return cmd.act == fetch_write_act || cmd.act == evict_act || cmd.act == writeback_act; }
+  constexpr inline bool is_prefetch(coh_cmd_t cmd)       { return cmd.act == prefetch_act;    }
 
   // generate command
   constexpr inline coh_cmd_t cmd_for_read()              { return {-1, acquire_msg, fetch_read_act }; }
   constexpr inline coh_cmd_t cmd_for_write()             { return {-1, acquire_msg, fetch_write_act}; }
+  constexpr inline coh_cmd_t cmd_for_prefetch()          { return {-1, acquire_msg, prefetch_act   }; }
   constexpr inline coh_cmd_t cmd_for_flush()             { return {-1, flush_msg,   evict_act      }; }
   constexpr inline coh_cmd_t cmd_for_writeback()         { return {-1, flush_msg,   writeback_act  }; }
   constexpr inline coh_cmd_t cmd_for_release()           { return {-1, release_msg, evict_act      }; }

--- a/cache/coherence.hpp
+++ b/cache/coherence.hpp
@@ -221,7 +221,7 @@ public:
 
     if (data_inner && data) data_inner->copy(data);
     Policy::meta_after_grant(cmd, meta, meta_inner);
-    cache->hook_read(addr, ai, s, w, hit, meta, data, delay);
+    cache->hook_read(addr, ai, s, w, hit, coh::is_prefetch(cmd), meta, data, delay);
     finish_record(addr, coh::cmd_for_finish(cmd.id), !hit, meta, ai, s);
     if(cmd.id == -1) finish_resp(addr, coh::cmd_for_finish(cmd.id));
   }
@@ -447,7 +447,7 @@ public:
     addr = normalize(addr);
     auto cmd = coh::cmd_for_read();
     auto [meta, data, ai, s, w, hit] = this->access_line(addr, cmd, XactPrio::acquire, delay);
-    cache->hook_read(addr, ai, s, w, hit, meta, data, delay);
+    cache->hook_read(addr, ai, s, w, hit, false, meta, data, delay);
     if constexpr (EnMT) { meta->unlock(); cache->reset_mt_state(ai, s, XactPrio::acquire);}
     if(!hit) outer->finish_req(addr);
 #ifdef CHECK_MULTI

--- a/cache/exclusive.hpp
+++ b/cache/exclusive.hpp
@@ -131,10 +131,10 @@ public:
     return true; // ToDo: support multithread
   }
 
-  virtual void hook_read(uint64_t addr, uint32_t ai, uint32_t s, uint32_t w, bool hit, const CMMetadataBase *meta, const CMDataBase *data, uint64_t *delay) override {
+  virtual void hook_read(uint64_t addr, uint32_t ai, uint32_t s, uint32_t w, bool hit, bool prefetch, const CMMetadataBase *meta, const CMDataBase *data, uint64_t *delay) override {
     if(ai < P) {
-      if(w >= NW) ext_replacer[ai].access(s, w-NW, true, false);
-      else        replacer[ai].access(s, w, true, false);
+      if(w >= NW) ext_replacer[ai].access(s, w-NW, true, prefetch);
+      else        replacer[ai].access(s, w, true, prefetch);
       if constexpr (EnMon || !C_VOID<DLY>) monitors->hook_read(addr, ai, s, w, hit, meta, data, delay);
     } else {
       if constexpr (EnMon || !C_VOID<DLY>) monitors->hook_read(addr, -1, -1, -1, hit, meta, data, delay);
@@ -187,7 +187,7 @@ public:
 
     if (data_inner && data) data_inner->copy(data);
     Policy::meta_after_grant(cmd, meta, meta_inner);
-    cache->hook_read(addr, ai, s, w, hit, meta, data, delay);
+    cache->hook_read(addr, ai, s, w, hit, coh::is_prefetch(cmd), meta, data, delay);
 
     cache->meta_return_buffer(meta);
     cache->data_return_buffer(data);
@@ -355,18 +355,18 @@ protected:
   using InnerCohPortBase::outer;
 
 public:
-  virtual void acquire_resp(uint64_t addr, CMDataBase *data_inner, CMMetadataBase *meta_inner, coh_cmd_t outer_cmd, uint64_t *delay) override {
-    auto [meta, data, ai, s, w, hit] = access_line(addr, outer_cmd, XactPrio::acquire, delay);
+  virtual void acquire_resp(uint64_t addr, CMDataBase *data_inner, CMMetadataBase *meta_inner, coh_cmd_t cmd, uint64_t *delay) override {
+    auto [meta, data, ai, s, w, hit] = access_line(addr, cmd, XactPrio::acquire, delay);
 
     if (data_inner && data) data_inner->copy(data);
-    Policy::meta_after_grant(outer_cmd, meta, meta_inner);
-    cache->hook_read(addr, ai, s, w, hit, meta, data, delay);
+    Policy::meta_after_grant(cmd, meta, meta_inner);
+    cache->hook_read(addr, ai, s, w, hit, coh::is_prefetch(cmd), meta, data, delay);
 
     // difficult to know when data is borrowed from buffer, just return it.
     cache->data_return_buffer(data);
 
-    this->finish_record(addr, coh::cmd_for_finish(outer_cmd.id), !hit, meta, ai, s);
-    if(outer_cmd.id == -1) this->finish_resp(addr, coh::cmd_for_finish(outer_cmd.id));
+    this->finish_record(addr, coh::cmd_for_finish(cmd.id), !hit, meta, ai, s);
+    if(cmd.id == -1) this->finish_resp(addr, coh::cmd_for_finish(cmd.id));
   }
 
 protected:

--- a/cache/memory.hpp
+++ b/cache/memory.hpp
@@ -101,7 +101,7 @@ public:
       data_inner->write(mem_addr);
     }
     if(meta_inner) meta_inner->to_modified(-1);
-    hook_read(addr, 0, 0, 0, true, meta_inner, data_inner, delay);
+    hook_read(addr, 0, 0, 0, true, false, meta_inner, data_inner, delay);
 #ifdef CHECK_MULTI
     if constexpr (EnMT) active_addr_remove(addr);
 #endif
@@ -130,7 +130,7 @@ public:
   // support run-time assign/reassign mointors
   void detach_monitor() { monitors->detach_monitor(); }
 
-  virtual void hook_read(uint64_t addr, uint32_t ai, uint32_t s, uint32_t w, bool hit, const CMMetadataBase *meta, const CMDataBase *data, uint64_t *delay) override {
+  virtual void hook_read(uint64_t addr, uint32_t ai, uint32_t s, uint32_t w, bool hit, bool prefetch, const CMMetadataBase *meta, const CMDataBase *data, uint64_t *delay) override {
     if constexpr (EnMon || !C_VOID<DLY>) monitors->hook_read(addr, -1, -1, -1, hit, meta, data, delay);
   }
 

--- a/cache/mi.hpp
+++ b/cache/mi.hpp
@@ -70,14 +70,12 @@ struct MIPolicy : public CohPolicyBase
     }
   }
 
-  static __always_inline std::tuple<bool, bool, coh_cmd_t> flush_need_sync(coh_cmd_t cmd, const CMMetadataBase *meta) {
-    if constexpr (uncached) {
-      if(meta){
-        if(coh::is_evict(cmd)) return std::make_tuple(true, true,  coh::cmd_for_probe_release());
-        else                   return std::make_tuple(true, true,  coh::cmd_for_probe_writeback());
-      } else                   return std::make_tuple(true, false, coh::cmd_for_null());
-    } else
-      return std::make_tuple(false, false, coh::cmd_for_null());
+  static __always_inline std::pair<bool, coh_cmd_t> flush_need_sync(coh_cmd_t cmd, const CMMetadataBase *meta) {
+    assert(uncached);
+    if(meta){
+      if(coh::is_evict(cmd)) return std::make_pair(true,  coh::cmd_for_probe_release());
+      else                   return std::make_pair(true,  coh::cmd_for_probe_writeback());
+    } else                   return std::make_pair(false, coh::cmd_for_null());
   }
 
 };

--- a/cache/mirage.hpp
+++ b/cache/mirage.hpp
@@ -156,12 +156,12 @@ public:
     return true; // ToDo: support multithread
   }
 
-  virtual void hook_read(uint64_t addr, uint32_t ai, uint32_t s, uint32_t w, bool hit, const CMMetadataBase * meta, const CMDataBase *data, uint64_t *delay) override {
+  virtual void hook_read(uint64_t addr, uint32_t ai, uint32_t s, uint32_t w, bool hit, bool prefetch, const CMMetadataBase * meta, const CMDataBase *data, uint64_t *delay) override {
     if(ai < P) {
       auto [ds, dw] = static_cast<MT *>(this->access(ai, s, w))->pointer();
-      d_replacer.access(ds, dw, true, false);
+      d_replacer.access(ds, dw, true, prefetch);
     }
-    CacheT::hook_read(addr, ai, s, w, hit, meta, data, delay);
+    CacheT::hook_read(addr, ai, s, w, hit, prefetch, meta, data, delay);
   }
 
   virtual void hook_write(uint64_t addr, uint32_t ai, uint32_t s, uint32_t w, bool hit, bool demand_acc, const CMMetadataBase * meta, const CMDataBase *data, uint64_t *delay) override {
@@ -206,7 +206,7 @@ public:
       auto [meta, addr] = this->relocate(m_ai, m_s, m_w, *ai, *s, *w);
       get_data_meta(static_cast<MT *>(meta))->bind(*ai, *s, *w);
       CacheT::hook_manage(addr, m_ai, m_s, m_w, true, true, false, nullptr, nullptr, delay);
-      CacheT::hook_read(addr, *ai, *s, *w, false, nullptr, nullptr, delay); // read or write? // hit is true or false? may have impact on delay
+      CacheT::hook_read(addr, *ai, *s, *w, false, false, nullptr, nullptr, delay); // read or write? // hit is true or false? may have impact on delay
       std::tie(*ai, *s, *w) = std::make_tuple(m_ai, m_s, m_w);
     }
   }

--- a/cache/msi.hpp
+++ b/cache/msi.hpp
@@ -46,7 +46,7 @@ struct MSIPolicy : public MIPolicy<isL1, uncached, Outer>
 
   static __always_inline void meta_after_fetch(coh_cmd_t outer_cmd, CMMetadataBase *meta, uint64_t addr) {
     meta->init(addr);
-    if(coh::is_fetch_read(outer_cmd)) meta->to_shared(-1);
+    if(coh::is_fetch_read(outer_cmd)||coh::is_prefetch(outer_cmd)) meta->to_shared(-1);
     else {
       assert(coh::is_fetch_write(outer_cmd) && meta->allow_write());
       meta->to_modified(-1);

--- a/cache/msi.hpp
+++ b/cache/msi.hpp
@@ -93,18 +93,13 @@ struct MSIPolicy : public MIPolicy<isL1, uncached, Outer>
     }
   }
 
-  static __always_inline std::tuple<bool, bool, coh_cmd_t> flush_need_sync(coh_cmd_t cmd, const CMMetadataBase *meta) {
-    if constexpr (uncached) {
-      if(meta) {
-        if(coh::is_evict(cmd)) return std::make_tuple(true, true, coh::cmd_for_probe_release());
-        else if(meta->is_shared())
-          return std::make_tuple(true, false, coh::cmd_for_null());
-        else
-          return std::make_tuple(true, true, coh::cmd_for_probe_writeback());
-      } else
-        return std::make_tuple(true, false, coh::cmd_for_null());
-    } else
-      return std::make_tuple(false, false, coh::cmd_for_null());
+  static __always_inline std::pair<bool, coh_cmd_t> flush_need_sync(coh_cmd_t cmd, const CMMetadataBase *meta) {
+    assert(uncached);
+    if(meta) {
+      if(coh::is_evict(cmd))     return std::make_pair(true,  coh::cmd_for_probe_release());
+      else if(meta->is_shared()) return std::make_pair(false, coh::cmd_for_null());
+      else                       return std::make_pair(true,  coh::cmd_for_probe_writeback());
+    } else                       return std::make_pair(false, coh::cmd_for_null());
   }
 };
 

--- a/util/monitor.hpp
+++ b/util/monitor.hpp
@@ -65,8 +65,8 @@ public:
   MonitorContainerBase *monitors; // monitor container
 
   // hook interface for replacer state update, Monitor and delay estimation
-  virtual void hook_read(uint64_t addr, uint32_t ai, uint32_t s, uint32_t w, bool hit, const CMMetadataBase *meta, const CMDataBase *data, uint64_t *delay) = 0;
-  virtual void hook_write(uint64_t addr, uint32_t ai, uint32_t s, uint32_t w, bool hit, bool is_release, const CMMetadataBase *meta, const CMDataBase *data, uint64_t *delay) = 0;
+  virtual void hook_read(uint64_t addr, uint32_t ai, uint32_t s, uint32_t w, bool hit, bool prefetch, const CMMetadataBase *meta, const CMDataBase *data, uint64_t *delay) = 0;
+  virtual void hook_write(uint64_t addr, uint32_t ai, uint32_t s, uint32_t w, bool hit, bool demand_acc, const CMMetadataBase *meta, const CMDataBase *data, uint64_t *delay) = 0;
   // probe, invalidate and writeback
   virtual void hook_manage(uint64_t addr, uint32_t ai, uint32_t s, uint32_t w, bool hit, bool evict, bool writeback, const CMMetadataBase *meta, const CMDataBase *data, uint64_t *delay) = 0;
   // an interface for special communication with a specific monitor if attached


### PR DESCRIPTION
Currently, a prefetch would bring a cache line into the LLC only and place it on the eviction candidate position.