### PR TITLE
lock all probe

### DIFF
--- a/cache/coh_policy.hpp
+++ b/cache/coh_policy.hpp
@@ -119,9 +119,9 @@ struct CohPolicyBase {
   }
 
   // writeback due to conflict, probe, flush
-  static __always_inline std::pair<bool, coh_cmd_t> writeback_need_sync(const CMMetadataBase *meta) {
-    return std::make_pair(true, coh::cmd_for_probe_release());
-  }
+  // static __always_inline std::pair<bool, coh_cmd_t> writeback_need_sync(const CMMetadataBase *meta) {
+  //   return std::make_pair(true, coh::cmd_for_probe_release());
+  // }
 
   // static __always_inline std::pair<bool, coh_cmd_t> writeback_need_writeback(const CMMetadataBase *meta);
 

--- a/cache/coherence.hpp
+++ b/cache/coherence.hpp
@@ -254,17 +254,17 @@ protected:
     // evict a block due to conflict
     auto addr = meta->addr(s);
     assert(cache->hit(addr));
-    if constexpr (EnMT && Policy::evict_need_lock()) cache->set_mt_state(ai, s, XactPrio::evict);
     auto sync = Policy::writeback_need_sync(meta);
     if(sync.first) {
+      if constexpr (EnMT && Policy::probe_need_lock()) cache->set_mt_state(ai, s, XactPrio::evict);
       auto [phit, pwb] = probe_req(addr, meta, data, sync.second, delay); // sync if necessary
       if(pwb) cache->hook_write(addr, ai, s, w, true, false, meta, data, delay); // a write occurred during the probe
+      if constexpr (EnMT && Policy::probe_need_lock()) cache->reset_mt_state(ai, s, XactPrio::evict);
     }
     auto writeback = Policy::writeback_need_writeback(meta);
     if(writeback.first) outer->writeback_req(addr, meta, data, writeback.second, delay); // writeback if dirty
     Policy::meta_after_evict(meta);
     cache->hook_manage(addr, ai, s, w, true, true, writeback.first, meta, data, delay);
-    if constexpr (EnMT && Policy::evict_need_lock()) cache->reset_mt_state(ai, s, XactPrio::evict);
   }
 
   virtual std::tuple<bool, CMMetadataBase *, CMDataBase *, uint32_t, uint32_t, uint32_t>
@@ -315,8 +315,10 @@ protected:
     if(hit) {
       auto sync = Policy::access_need_sync(cmd, meta);
       if(sync.first) {
+        if constexpr (EnMT && Policy::probe_need_lock()) { assert(prio < XactPrio::evict); cache->set_mt_state(ai, s, XactPrio::evict); }
         auto [phit, pwb] = probe_req(addr, meta, data, sync.second, delay); // sync if necessary
         if(pwb) cache->hook_write(addr, ai, s, w, true, false, meta, data, delay); // a write occurred during the probe
+        if constexpr (EnMT && Policy::probe_need_lock()) cache->reset_mt_state(ai, s, XactPrio::evict); 
       }
       auto [promote, promote_local, promote_cmd] = Policy::access_need_promote(cmd, meta);
       if(promote) { outer->acquire_req(addr, meta, data, promote_cmd, delay); hit = false; } // promote permission if needed
@@ -346,10 +348,11 @@ protected:
       auto [probe, probe_cmd] = Policy::flush_need_sync(cmd, meta);
       if(!hit) return;
 
-      if constexpr (EnMT && Policy::evict_need_lock()) cache->set_mt_state(ai, s, XactPrio::evict);
       if(probe) {
+        if constexpr (EnMT && Policy::probe_need_lock()) cache->set_mt_state(ai, s, XactPrio::evict);
         auto [phit, pwb] = probe_req(addr, meta, data, probe_cmd, delay); // sync if necessary
         if(pwb) cache->hook_write(addr, ai, s, w, true, false, meta, data, delay); // a write occurred during the probe
+        if constexpr (EnMT && Policy::probe_need_lock()) cache->reset_mt_state(ai, s, XactPrio::evict);
       }
 
       auto writeback = Policy::writeback_need_writeback(meta);
@@ -358,10 +361,7 @@ protected:
       Policy::meta_after_flush(cmd, meta, cache);
       cache->hook_manage(addr, ai, s, w, hit, coh::is_evict(cmd), writeback.first, meta, data, delay);
 
-      if constexpr (EnMT) { 
-        if constexpr (Policy::evict_need_lock()) cache->reset_mt_state(ai, s, XactPrio::evict);
-        meta->unlock(); cache->reset_mt_state(ai, s, XactPrio::flush); 
-      }
+      if constexpr (EnMT) { meta->unlock(); cache->reset_mt_state(ai, s, XactPrio::flush); }
     }
   }
 

--- a/cache/mi.hpp
+++ b/cache/mi.hpp
@@ -21,12 +21,13 @@ struct MIPolicy : public CohPolicyBase
 {
   constexpr static __always_inline bool is_uncached() { return uncached; }
 
-  constexpr static __always_inline bool evict_need_lock() { return !(uncached || isL1); }
+  constexpr static __always_inline bool probe_need_lock() { return !(uncached || isL1); }
 
   static __always_inline coh_cmd_t cmd_for_outer_acquire(coh_cmd_t cmd) { return coh::cmd_for_write(); }
 
   static __always_inline std::pair<bool, coh_cmd_t> access_need_sync(coh_cmd_t cmd, const CMMetadataBase *meta) {
-    return std::make_pair(true, coh::cmd_for_probe_release(cmd.id));
+    if constexpr (isL1) return std::make_pair(false, coh::cmd_for_null());
+    else                return std::make_pair(true, coh::cmd_for_probe_release(cmd.id));
   }
 
   static __always_inline std::tuple<bool, bool, coh_cmd_t> access_need_promote(coh_cmd_t cmd, const CMMetadataBase *meta) {
@@ -74,10 +75,17 @@ struct MIPolicy : public CohPolicyBase
 
   static __always_inline std::pair<bool, coh_cmd_t> flush_need_sync(coh_cmd_t cmd, const CMMetadataBase *meta) {
     assert(uncached);
-    if(meta){
-      if(coh::is_evict(cmd)) return std::make_pair(true,  coh::cmd_for_probe_release());
-      else                   return std::make_pair(true,  coh::cmd_for_probe_writeback());
-    } else                   return std::make_pair(false, coh::cmd_for_null());
+    if constexpr (!isL1){
+      if(meta){
+        if(coh::is_evict(cmd)) return std::make_pair(true,  coh::cmd_for_probe_release());
+        else                   return std::make_pair(true,  coh::cmd_for_probe_writeback());
+      } else                   return std::make_pair(false, coh::cmd_for_null());
+    } else return std::make_pair(false, coh::cmd_for_null());
+  }
+
+  static __always_inline std::pair<bool, coh_cmd_t> writeback_need_sync(const CMMetadataBase *meta) {
+    if constexpr (isL1) return std::make_pair(false, coh::cmd_for_null());
+    else                return std::make_pair(true, coh::cmd_for_probe_release());
   }
 
 };


### PR DESCRIPTION
这个PR是PR #150 的延续版本，
一个三级缓存包含私有的L1-A、L1-B、L2-A、L2-B以及末级缓存LLC，地址X存在于二级缓存L2-B和LLC中，B线程从L1-B向L2-B发起acquire 地址X的请求，它在L2-B拿到X对应缓存集合的控制权以及X的缓存锁, 此时A线程向L2-B也发起了probe X的请求，那么可能会出现如下情况：
（1）B线程由于access_sync函数在L2-B向L1-B发起了probe X的请求(代码中只要缓存块是M状态就需要发起probe)，在发起probe时将L2-B的X对应的meta解锁
（2）A线程在L2-B拿到X的meta锁，也向L1-B发起了probe X的请求，因此也将L2-B中X的meta解了锁，因此同时存在两个线程同时对L1-B发起了probe请求
（3）B线程先完成L1-B的probe X请求，之后回到二级缓存将数据拷贝回L1-B中，A线程返回L2-B后将缓存块无效掉（因此X存在于L1-B中但不存在于L2-B中了）

因此问题出在了access_sync引起的probe上，和PR #150的解决方案相同，如果本级cache不是uncached也不是L1，那么所有发起probe的cache都需要升级缓存集合的权限以阻止其他的probe。